### PR TITLE
allow post types to be excluded on homepage and archives

### DIFF
--- a/simplyexclude.php
+++ b/simplyexclude.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: Simply Exclude
 Plugin URI: http://www.codehooligans.com/projects/wordpress/simply-exclude/
-Description: Provides an interface to selectively exclude/include all Taxonomies, Post Types and Users from the 4 actions used by WordPress. is_front, is_archive, is_search, is_feed. Also provides access to some of the common widgets user like tag cloud and categories listings. 
+Description: Provides an interface to selectively exclude/include all Taxonomies, Post Types and Users from the 4 actions used by WordPress. is_front, is_archive, is_search, is_feed. Also provides access to some of the common widgets user like tag cloud and categories listings.
 Author: Paul Menard
 Version: 2.0.6.2
 Author URI: http://www.codehooligans.com
@@ -15,42 +15,42 @@ class SimplyExclude
 	public $se_version;
 	public $admin_menu_label;
 	public $options_key;
-		
+
 	public $se_taxonomies_exclude = array();
 	public $se_post_types_exclude = array();
-	
+
 	private $plugindir_url;
 
 	private $current_taxonomy;
 	private $current_post_type;
 	private $current_se_type;
-	
+
 	private $page_hooks;
-	
+
 	private $tabs = array();
 	private $current_tab;
-	
+
 	public function __construct() {
-		
+
 		$this->se_version	= "2.0.6.2";
-		
+
 		$this->admin_menu_label	= __("Simply Exclude", SIMPLY_EXCLUDE_I18N_DOMAIN);
 		$this->options_key		= "simplyexclude_v2";
-		
-		$plugindir_node 		= dirname(plugin_basename(__FILE__));	
+
+		$plugindir_node 		= dirname(plugin_basename(__FILE__));
 		$this->plugindir_url 	= WP_PLUGIN_URL . "/". $plugindir_node;
-		
+
 		$this->se_taxonomies_exclude = array('media-tags', 'post_format', 'link_category', 'nav_menu');
-		$this->se_post_types_exclude = array('revision', 'nav_menu_item', 'attachment');		
+		$this->se_post_types_exclude = array('revision', 'nav_menu_item', 'attachment');
 		$this->page_hooks = array();
-		
+
 		/* Setup the tetdomain for i18n language handling see http://codex.wordpress.org/Function_Reference/load_plugin_textdomain */
         load_plugin_textdomain( SIMPLY_EXCLUDE_I18N_DOMAIN, false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
-		
+
 		add_action( 'init', array(&$this,'init_proc') );
 		add_action( 'admin_init', array(&$this,'admin_init_proc') );
 		add_action( 'admin_menu', array(&$this,'se_add_nav') );
-		add_action( 'admin_footer', array(&$this,'se_admin_footer') );				
+		add_action( 'admin_footer', array(&$this,'se_admin_footer') );
 		add_action( 'wp_ajax_se_update', array(&$this, 'se_ajax_update') );
 
 		// Used to limit the categories displayed on the home page. Simple
@@ -59,50 +59,50 @@ class SimplyExclude
 
 	function admin_init_proc()
 	{
-		
-		$this->tabs = array( 	
+
+		$this->tabs = array(
 		 	'taxonomies'  	=> __('Taxonomies', SIMPLY_EXCLUDE_I18N_DOMAIN),
     		'post_types'	=> __('Post Types', SIMPLY_EXCLUDE_I18N_DOMAIN),
     		'users'			=> __('Users', SIMPLY_EXCLUDE_I18N_DOMAIN),
 		);
 		$this->current_tab = '';
-	    
+
 		$this->se_load_config();
-						
-		if ( ($this->check_url('wp-admin/edit-tags.php'))		
+
+		if ( ($this->check_url('wp-admin/edit-tags.php'))
 		  || ($this->check_url('wp-admin/edit.php'))
 		  || ($this->check_url('wp-admin/users.php')) )
-		{			
+		{
 			wp_enqueue_style( 'simplyexclude-stylesheet', $this->plugindir_url .'/simplyexclude_style_admin.css', false, $this->se_version);
 
-			wp_enqueue_script('jquery'); 
-			wp_enqueue_script('jquery-ui-core'); 
+			wp_enqueue_script('jquery');
+			wp_enqueue_script('jquery-ui-core');
 			wp_enqueue_script('jquery-ui-dialog');
-			
-			wp_enqueue_style( 'simplyexclude-jquery-ui', 
+
+			wp_enqueue_style( 'simplyexclude-jquery-ui',
 				$this->plugindir_url .'/js/jquery-ui/css/flick/jquery-ui-1.8.17.custom.css',
 				null, $this->se_version );
-			
+
 			wp_enqueue_script('simplyexclude-admin-dialog-js', $this->plugindir_url .'/js/simplyexclude_admin_dialog.js',
-				array('jquery', 'jquery-ui-core', 'jquery-ui-dialog'), $this->se_version);			
+				array('jquery', 'jquery-ui-core', 'jquery-ui-dialog'), $this->se_version);
 
 			wp_enqueue_script('simplyexclude-admin-ajax-js', $this->plugindir_url .'/js/simplyexclude_admin_ajax.js',
-				array('jquery', 'jquery-ui-core'), $this->se_version);			
+				array('jquery', 'jquery-ui-core'), $this->se_version);
 		}
-						
+
 		add_action('edit_category_form_fields', array(&$this,'se_show_taxonomy_term_fields'), 99, 1);
 		add_action('edit_tag_form_fields', array(&$this,'se_show_taxonomy_term_fields'), 99, 1);
 		add_action('edited_term', array(&$this,'se_save_taxonomy_term_fields'), 99, 3);
-		
+
 		add_action( 'show_user_profile', array(&$this,'se_show_user_profile'), 99 );
 		add_action( 'edit_user_profile', array(&$this,'se_show_user_profile'), 99 );
-		
+
 		add_action( 'profile_update', array(&$this,'se_save_user_profile'), 99);
-		
+
 		add_filter( 'plugin_action_links_'. basename( dirname( __FILE__ ) ). '/' .basename( __FILE__ ), array(&$this,'plugin_settings'));
-		
+
 	}
-	
+
 	// Adds a 'Settings' link on the Plugins listing row. Cool!
 	function plugin_settings( $links ) {
 		$settings_link = '<a href="admin.php?page=se_manage_settings">'.__( 'Settings', SIMPLY_EXCLUDE_I18N_DOMAIN ).'</a>';
@@ -110,47 +110,47 @@ class SimplyExclude
 
 		return $links;
 	}
-	
+
 	function init_proc()
 	{
 		if (!is_admin())
 		{
-			add_filter('widget_pages_args', array(&$this, 'se_widget_pages_args_proc'));	
-			
-			// Not needed since wp_list_pages is user managable. 
+			add_filter('widget_pages_args', array(&$this, 'se_widget_pages_args_proc'));
+
+			// Not needed since wp_list_pages is user managable.
 			//aad_filter('wp_list_pages_excludes', array(&$this, 'se_wp_list_pages_excludes_proc'));
-			
+
 			// Suport for the Category list/dropdown widget
-			add_filter('widget_categories_dropdown_args', array(&$this, 'se_widget_categories_dropdown_args_proc'));	
-			add_filter('widget_categories_args', array(&$this, 'se_widget_categories_dropdown_args_proc'));	
+			add_filter('widget_categories_dropdown_args', array(&$this, 'se_widget_categories_dropdown_args_proc'));
+			add_filter('widget_categories_args', array(&$this, 'se_widget_categories_dropdown_args_proc'));
 
 			// Support for the Tag Clod widget. This widget supports both the post_tag and category taxonomies.
-			add_filter('widget_tag_cloud_args', array(&$this, 'se_widget_tag_cloud_args_proc'));	
+			add_filter('widget_tag_cloud_args', array(&$this, 'se_widget_tag_cloud_args_proc'));
 		}
 	}
-	
-	function se_add_nav() 
+
+	function se_add_nav()
 	{
 		// Add the Main Nav item to the WP menu
-		add_menu_page( 'Simply Exclude', 'Simply Exclude', 'manage_options', 'se_manage_settings', 
+		add_menu_page( 'Simply Exclude', 'Simply Exclude', 'manage_options', 'se_manage_settings',
 			array(&$this, 'se_manage_settings'));
 
 		// Add our Options sub menu.
-		$this->pagehooks['se_manage_settings'] = add_submenu_page( 'se_manage_settings', 'Settings', 'Settings', 'manage_options', 
+		$this->pagehooks['se_manage_settings'] = add_submenu_page( 'se_manage_settings', 'Settings', 'Settings', 'manage_options',
 			'se_manage_settings', array(&$this, 'se_manage_settings'));
 		add_action('load-'. $this->pagehooks['se_manage_settings'], array(&$this, 'on_load_settings_page'));
 
 
 		// Add our Help sub menu.
-		$this->pagehooks['se_manage_help'] = add_submenu_page( 'se_manage_settings', 'Help', 'Help', 'manage_options', 
+		$this->pagehooks['se_manage_help'] = add_submenu_page( 'se_manage_settings', 'Help', 'Help', 'manage_options',
 			'se_manage_help', array(&$this, 'se_manage_help'));
 		add_action('load-'. $this->pagehooks['se_manage_help'], array(&$this, 'on_load_help_page'));
-		
+
 		if ( !current_user_can('manage_options') )
 			return;
-			
+
 		$this->se_load_config();
-		
+
 		// Now add a submenu for each registered taxonomy
 		$se_taxonomies = $this->se_load_taxonomy_list();
 		if ($se_taxonomies)
@@ -161,10 +161,10 @@ class SimplyExclude
 				 && ($this->se_cfg['data']['taxonomies'][$t_item->name]['options']['showhide'] == 'show'))
 				{
 					add_filter( "manage_edit-". $t_item->name ."_columns", array( &$this, 'se_manage_taxonomy_columns' ), 99, 1);
-					add_filter( "manage_". $t_item->name. "_custom_column", array(&$this, 'se_display_taxonomy_column_filters'), 99, 3);										
+					add_filter( "manage_". $t_item->name. "_custom_column", array(&$this, 'se_display_taxonomy_column_filters'), 99, 3);
 				}
 			}
-			//add_action("delete_term", array(&$this, 'se_delete_taxonomy_term'), 99, 3);			
+			//add_action("delete_term", array(&$this, 'se_delete_taxonomy_term'), 99, 3);
 		}
 
 		// Now add a submenu for each registered post_type
@@ -177,14 +177,14 @@ class SimplyExclude
 				 && ($this->se_cfg['data']['post_types'][$t_item->name]['options']['showhide'] == 'show'))
 				{
 					add_filter( "manage_". $t_item->name ."_posts_columns", array( &$this, 'se_manage_post_type_columns' ), 99 );
-					add_action( "manage_". $t_item->name ."_posts_custom_column", array(&$this, 'se_display_post_type_column_actions'), 99, 2); 
-			
-					add_meta_box($this->options_key, $this->admin_menu_label, array(&$this,'show_post_type_exclude_sidebar_dbx'), $t_item->name, 'side');								
-					add_action('save_post', array(&$this,'save_post_type_exclude_sidebar_dbx'));				
+					add_action( "manage_". $t_item->name ."_posts_custom_column", array(&$this, 'se_display_post_type_column_actions'), 99, 2);
+
+					add_meta_box($this->options_key, $this->admin_menu_label, array(&$this,'show_post_type_exclude_sidebar_dbx'), $t_item->name, 'side');
+					add_action('save_post', array(&$this,'save_post_type_exclude_sidebar_dbx'));
 				}
 			}
 		}
-		
+
 		// Users table
 		if ((isset($this->se_cfg['data']['se_types']['users']['options']['showhide']))
 		 && ($this->se_cfg['data']['se_types']['users']['options']['showhide'] == 'show'))
@@ -194,28 +194,28 @@ class SimplyExclude
 		}
 	}
 
-/*		
+/*
 	function se_delete_taxonomy_term($term, $tt_id, $taxonomy)
 	{
 		echo "term<pre>"; print_r($term); echo "</pre>";
 		echo "tt_id=[". $tt_id ."]<br />";
 		echo "taxonomy=[". $taxonomy ."]<br />";
-		
+
 		exit;
 	}
 */
-		
+
 	/****************************************************************************************************************************/
 	/*																															*/
 	/*												ON LOAD PAGES																*/
 	/*																															*/
 	/****************************************************************************************************************************/
-		
+
 	function on_load_settings_page() {
 
 		wp_enqueue_style( 'simplyexclude-stylesheet', $this->plugindir_url .'/simplyexclude_style_admin.css', false, $this->se_version);
 		wp_enqueue_script('simplyexclude-admin-ajax-js', $this->plugindir_url .'/js/simplyexclude_admin_ajax.js',
-			array('jquery', 'jquery-ui-core'), $this->se_version);			
+			array('jquery', 'jquery-ui-core'), $this->se_version);
 
 		wp_enqueue_script('common');
 		wp_enqueue_script('wp-lists');
@@ -226,9 +226,9 @@ class SimplyExclude
 			if (!isset($this->tabs[$this->current_tab])) {
 				$this->current_tab = 'taxonomies';
 			}
-			
+
 		} else {
-			$this->current_tab = 'taxonomies'; 
+			$this->current_tab = 'taxonomies';
 		}
 
 		add_meta_box('se_settings_about_sidebar', 'About this Plugin', array(&$this, 'se_settings_about_sidebar'),
@@ -240,38 +240,38 @@ class SimplyExclude
 
 	function on_load_help_page()
 	{
-		global $wp_version; 
-		
+		global $wp_version;
+
 		wp_enqueue_style( 'simplyexclude-stylesheet', $this->plugindir_url .'/simplyexclude_style_admin.css', false, $this->se_version);
-		
-		wp_enqueue_script('jquery'); 
-		wp_enqueue_script('jquery-ui-core'); 
+
+		wp_enqueue_script('jquery');
+		wp_enqueue_script('jquery-ui-core');
 
 	    if ( version_compare( $wp_version, '3.3', '<' ) ) {
-			wp_register_script( 'jquery-ui-widget-se', $this->plugindir_url .'/js/jquery-ui/jquery.ui.widget.min.js', 
+			wp_register_script( 'jquery-ui-widget-se', $this->plugindir_url .'/js/jquery-ui/jquery.ui.widget.min.js',
 				array('jquery', 'jquery-ui-core'), $this->se_version);
 		    wp_enqueue_script( 'jquery-ui-widget-se' );
-			wp_register_script( 'jquery-ui-accordion-se', $this->plugindir_url .'/js/jquery-ui/jquery.ui.accordion.min.js', 
+			wp_register_script( 'jquery-ui-accordion-se', $this->plugindir_url .'/js/jquery-ui/jquery.ui.accordion.min.js',
 				array('jquery', 'jquery-ui-core', 'jquery-ui-widget-se'), $this->se_version);
 		    wp_enqueue_script( 'jquery-ui-accordion-se' );
-		
+
 		} else {
-			wp_enqueue_script('jquery-ui-widget');				
-			wp_enqueue_script('jquery-ui-accordion');							
+			wp_enqueue_script('jquery-ui-widget');
+			wp_enqueue_script('jquery-ui-accordion');
 		}
 
 		add_meta_box('se_settings_about_sidebar', 'About this Plugin', array(&$this, 'se_settings_about_sidebar'),
 			$this->pagehooks['se_manage_help'], 'side', 'core');
 		add_meta_box('se_settings_donate_sidebar', 'Make a Donation', array(&$this, 'se_settings_donate_sidebar'),
-			$this->pagehooks['se_manage_help'], 'side', 'core');		
+			$this->pagehooks['se_manage_help'], 'side', 'core');
 	}
-	
+
 	/****************************************************************************************************************************/
 	/*																															*/
 	/*												ACTIONS PANELS																*/
 	/*																															*/
 	/****************************************************************************************************************************/
-	
+
 	function se_show_taxonomy_actions_panel($taxonomy)
 	{
 		if (!$taxonomy)	return;
@@ -293,7 +293,7 @@ class SimplyExclude
 		<tbody>
 		<?php
 		$class="";
-		
+
 		foreach ($this->current_taxonomy['actions'] as $action_key => $action_val)
 		{
 			$class = ('alternate' == $class) ? '' : 'alternate';
@@ -309,12 +309,12 @@ class SimplyExclude
 			<tr>
 			<?php
 		}
-		?>				
+		?>
 		</tbody>
 		</table>
 		<?php
 	}
-		
+
 	function se_show_post_type_actions_panel($post_type='')
 	{
 		if (!$post_type) return;
@@ -345,16 +345,16 @@ class SimplyExclude
 				<td class="description"><?php echo $this->get_post_type_action_label($post_type, $action_key, 'description');  ?></td>
 				<td class="inc-excl">
 					<ul class="se-actions-list">
-					
+
 						<li><input type="radio" id="se_cfg_<?php echo $post_type ?>_actions_<?php echo $action_key ?>_i" name="se_cfg[<?php echo $post_type; ?>][actions][<?php echo $action_key ?>]" value="i" <?php if ($action_val == 'i') echo "checked='checked'"; ?> /> <label for="se_cfg_<?php echo $post_type ?>_actions_<?php echo $action_key ?>_i"><?php _e('Include only', SIMPLY_EXCLUDE_I18N_DOMAIN); ?></label></li>
 						<li><input type="radio" id="se_cfg_<?php echo $post_type ?>_actions_<?php echo $action_key ?>_e" name="se_cfg[<?php echo $post_type; ?>][actions][<?php echo $action_key ?>]" value="e" <?php if ($action_val == 'e') echo "checked='checked'"; ?> /> <label for="se_cfg_<?php echo $post_type ?>_actions_<?php echo $action_key ?>_e"><?php _e('Exclude', SIMPLY_EXCLUDE_I18N_DOMAIN); ?></label></li>
 						<?php
-							if (($action_key == "is_home") 
-						 		&& ((isset($this->current_post_type['options']['capability_type'])) 
+							if (($action_key == "is_home")
+						 		&& ((isset($this->current_post_type['options']['capability_type']))
 								&& ($this->current_post_type['options']['capability_type'] == "post"))) {
 								?><li><input type="radio" id="se_cfg_<?php echo $post_type ?>_actions_<?php echo $action_key ?>_a" name="se_cfg[<?php echo $post_type; ?>][actions][<?php echo $action_key ?>]" value="a" <?php if ($action_val == 'a') echo "checked='checked'"; ?> /> <label for="se_cfg_<?php echo $post_type ?>_actions_<?php echo $action_key ?>_a"><?php _e('Include All', SIMPLY_EXCLUDE_I18N_DOMAIN); ?></label></li><?php
-							} else if (($action_key == "is_feed") 
-						 		&& ((isset($this->current_post_type['options']['capability_type'])) 
+							} else if (($action_key == "is_feed")
+						 		&& ((isset($this->current_post_type['options']['capability_type']))
 								&& ($this->current_post_type['options']['capability_type'] == "post"))) {
 								?><li><input type="radio" id="se_cfg_<?php echo $post_type ?>_actions_<?php echo $action_key ?>_a" name="se_cfg[<?php echo $post_type; ?>][actions][<?php echo $action_key ?>]" value="a" <?php if ($action_val == 'a') echo "checked='checked'"; ?> /> <label for="se_cfg_<?php echo $post_type ?>_actions_<?php echo $action_key ?>_a"><?php _e('Include All', SIMPLY_EXCLUDE_I18N_DOMAIN); ?></label></li><?php
 							}
@@ -368,14 +368,14 @@ class SimplyExclude
 		</table>
 		<?php
 	}
-	
+
 	function se_show_se_type_actions_panel($se_type='')
 	{
 		if (!$se_type) return;
 
 		if (!isset($this->se_cfg['data']['se_types'][$se_type]))
 			return;
-			
+
 		$this->current_se_type = $this->se_cfg['data']['se_types'][$se_type];
 		?>
 		<table class="widefat simply-exclude-settings-postbox simplyexclude-actions-panel" cellpadding="3" cellspacing="3" border="0">
@@ -410,14 +410,14 @@ class SimplyExclude
 		</table>
 		<?php
 	}
-	
-	
+
+
 	/****************************************************************************************************************************/
 	/*																															*/
 	/*												ACTIVE PANELS																*/
 	/*																															*/
 	/****************************************************************************************************************************/
-	
+
 	function se_show_taxonomy_active_panel($taxonomy)
 	{
 		if (!$taxonomy)	return;
@@ -439,11 +439,11 @@ class SimplyExclude
 		<tr>
 			<td class="description"><?php _e("Is this Taxonomy active? This is sometimes convenient instead of unsetting all Taxonomy terms.", SIMPLY_EXCLUDE_I18N_DOMAIN); ?></td>
 			<td class="inc-excl">
-				<input type="radio" name="se_cfg[<?php echo $taxonomy; ?>][options][active]" value="yes" 
-					<?php if ($this->current_taxonomy['options']['active'] == 'yes') 
+				<input type="radio" name="se_cfg[<?php echo $taxonomy; ?>][options][active]" value="yes"
+					<?php if ($this->current_taxonomy['options']['active'] == 'yes')
 						echo "checked='checked'"; ?> /> <?php _e('Active', SIMPLY_EXCLUDE_I18N_DOMAIN); ?><br />
-				<input type="radio" name="se_cfg[<?php echo $taxonomy; ?>][options][active]" value="no" 
-					<?php if ($this->current_taxonomy['options']['active'] == 'no') 
+				<input type="radio" name="se_cfg[<?php echo $taxonomy; ?>][options][active]" value="no"
+					<?php if ($this->current_taxonomy['options']['active'] == 'no')
 						echo "checked='checked'"; ?> /> <?php _e('Disabled', SIMPLY_EXCLUDE_I18N_DOMAIN); ?>
 			</td>
 		</tr>
@@ -473,11 +473,11 @@ class SimplyExclude
 		<tr>
 			<td class="description"><?php _e("Is this Post Type Active? This is sometimes convenient instead of unsetting all Post Type items.", SIMPLY_EXCLUDE_I18N_DOMAIN); ?></td>
 			<td class="inc-excl">
-				<input type="radio" name="se_cfg[<?php echo $post_type; ?>][options][active]" value="yes" 
-					<?php if ($this->current_post_type['options']['active'] == 'yes') 
+				<input type="radio" name="se_cfg[<?php echo $post_type; ?>][options][active]" value="yes"
+					<?php if ($this->current_post_type['options']['active'] == 'yes')
 						echo "checked='checked'"; ?> /> <?php _e('Active', SIMPLY_EXCLUDE_I18N_DOMAIN); ?><br />
-				<input type="radio" name="se_cfg[<?php echo $post_type; ?>][options][active]" value="no" 
-					<?php if ($this->current_post_type['options']['active'] == 'no') 
+				<input type="radio" name="se_cfg[<?php echo $post_type; ?>][options][active]" value="no"
+					<?php if ($this->current_post_type['options']['active'] == 'no')
 						echo "checked='checked'"; ?> /> <?php _e('Disabled', SIMPLY_EXCLUDE_I18N_DOMAIN); ?>
 			</td>
 		</tr>
@@ -507,11 +507,11 @@ class SimplyExclude
 		<tr>
 			<td class="description"><?php _e("Active?", SIMPLY_EXCLUDE_I18N_DOMAIN); ?></td>
 			<td class="inc-excl">
-				<input type="radio" name="se_cfg[<?php echo $se_type; ?>][options][active]" value="yes" 
-					<?php if ($this->current_se_type['options']['active'] == 'yes') 
+				<input type="radio" name="se_cfg[<?php echo $se_type; ?>][options][active]" value="yes"
+					<?php if ($this->current_se_type['options']['active'] == 'yes')
 						echo "checked='checked'"; ?> /> <?php _e('Active', SIMPLY_EXCLUDE_I18N_DOMAIN); ?><br />
-				<input type="radio" name="se_cfg[<?php echo $se_type; ?>][options][active]" value="no" 
-					<?php if ($this->current_se_type['options']['active'] == 'no') 
+				<input type="radio" name="se_cfg[<?php echo $se_type; ?>][options][active]" value="no"
+					<?php if ($this->current_se_type['options']['active'] == 'no')
 						echo "checked='checked'"; ?> /> <?php _e('Disabled', SIMPLY_EXCLUDE_I18N_DOMAIN); ?>
 			</td>
 		</tr>
@@ -548,11 +548,11 @@ class SimplyExclude
 		<tr>
 			<td class="description"><?php _e("Show the extra columns on the Taxonomy listing and the Taxonomy edit form?", SIMPLY_EXCLUDE_I18N_DOMAIN); ?></td>
 			<td class="inc-excl">
-				<input type="radio" name="se_cfg[<?php echo $taxonomy; ?>][options][showhide]" value="show" 
-					<?php if ($this->current_taxonomy['options']['showhide'] == 'show') 
+				<input type="radio" name="se_cfg[<?php echo $taxonomy; ?>][options][showhide]" value="show"
+					<?php if ($this->current_taxonomy['options']['showhide'] == 'show')
 						echo "checked='checked'"; ?> /> <?php _e('Show', SIMPLY_EXCLUDE_I18N_DOMAIN); ?><br />
-				<input type="radio" name="se_cfg[<?php echo $taxonomy; ?>][options][showhide]" value="hide" 
-					<?php if ($this->current_taxonomy['options']['showhide'] == 'hide') 
+				<input type="radio" name="se_cfg[<?php echo $taxonomy; ?>][options][showhide]" value="hide"
+					<?php if ($this->current_taxonomy['options']['showhide'] == 'hide')
 						echo "checked='checked'"; ?> /> <?php _e('Hide', SIMPLY_EXCLUDE_I18N_DOMAIN); ?>
 			</td>
 		</tr>
@@ -579,11 +579,11 @@ class SimplyExclude
 		<tr>
 			<td class="description"><?php _e("Show the extra columns on the Post Type listing and the Post Type edit form?", SIMPLY_EXCLUDE_I18N_DOMAIN); ?></td>
 			<td class="inc-excl">
-				<input type="radio" name="se_cfg[<?php echo $post_type; ?>][options][showhide]" value="show" 
-					<?php if ($this->current_post_type['options']['showhide'] == 'show') 
+				<input type="radio" name="se_cfg[<?php echo $post_type; ?>][options][showhide]" value="show"
+					<?php if ($this->current_post_type['options']['showhide'] == 'show')
 						echo "checked='checked'"; ?> /> <?php _e('Show', SIMPLY_EXCLUDE_I18N_DOMAIN); ?><br />
-				<input type="radio" name="se_cfg[<?php echo $post_type; ?>][options][showhide]" value="hide" 
-					<?php if ($this->current_post_type['options']['showhide'] == 'hide') 
+				<input type="radio" name="se_cfg[<?php echo $post_type; ?>][options][showhide]" value="hide"
+					<?php if ($this->current_post_type['options']['showhide'] == 'hide')
 						echo "checked='checked'"; ?> /> <?php _e('Hide', SIMPLY_EXCLUDE_I18N_DOMAIN); ?>
 			</td>
 		</tr>
@@ -610,28 +610,28 @@ class SimplyExclude
 		<tr>
 			<td class="description"><?php _e("Show the extra columns on the listing and the edit form?", SIMPLY_EXCLUDE_I18N_DOMAIN); ?></td>
 			<td class="inc-excl">
-				<input type="radio" name="se_cfg[<?php echo $se_type; ?>][options][showhide]" value="show" 
-					<?php if ($this->current_se_type['options']['showhide'] == 'show') 
+				<input type="radio" name="se_cfg[<?php echo $se_type; ?>][options][showhide]" value="show"
+					<?php if ($this->current_se_type['options']['showhide'] == 'show')
 						echo "checked='checked'"; ?> /> <?php _e('Show', SIMPLY_EXCLUDE_I18N_DOMAIN); ?><br />
-				<input type="radio" name="se_cfg[<?php echo $se_type; ?>][options][showhide]" value="hide" 
-					<?php if ($this->current_se_type['options']['showhide'] == 'hide') 
+				<input type="radio" name="se_cfg[<?php echo $se_type; ?>][options][showhide]" value="hide"
+					<?php if ($this->current_se_type['options']['showhide'] == 'hide')
 						echo "checked='checked'"; ?> /> <?php _e('Hide', SIMPLY_EXCLUDE_I18N_DOMAIN); ?>
 			</td>
 		</tr>
 		</table>
 		<?php
 	}
-	
-	
-	
-	
-	
+
+
+
+
+
 	/****************************************************************************************************************************/
 	/*																															*/
 	/*												QUERY OVERRIDE PANELS														*/
 	/*																															*/
 	/****************************************************************************************************************************/
-	
+
 	function se_show_taxonomy_query_override_panel($taxonomy)
 	{
 		if (!$taxonomy)	return;
@@ -640,7 +640,7 @@ class SimplyExclude
 			return;
 
 		$this->current_taxonomy = $this->se_cfg['data']['taxonomies'][$taxonomy];
-		
+
 
 		?>
 		<table class="widefat simply-exclude-settings-postbox simplyexclude-active-panel" cellpadding="3" cellspacing="3" border="0">
@@ -656,11 +656,11 @@ class SimplyExclude
 				<p><?php _e("The Simply-Exclude plugin was designed to only work with the main page query. But sometimes other plugins or your theme will effect how the main filtering works. So if you are having trouble attempting to filter categories from your home page you might want to try and set this option to 'All' and see if it corrects your issue.", SIMPLY_EXCLUDE_I18N_DOMAIN); ?></p>
 				</td>
 			<td class="inc-excl">
-				<input type="radio" name="se_cfg[<?php echo $taxonomy; ?>][options][qover]" value="main" 
-					<?php if ($this->current_taxonomy['options']['qover'] == 'main') 
+				<input type="radio" name="se_cfg[<?php echo $taxonomy; ?>][options][qover]" value="main"
+					<?php if ($this->current_taxonomy['options']['qover'] == 'main')
 						echo "checked='checked'"; ?> /> <?php _e('Main Loop Only', SIMPLY_EXCLUDE_I18N_DOMAIN); ?><br />
-				<input type="radio" name="se_cfg[<?php echo $taxonomy; ?>][options][qover]" value="all" 
-					<?php if ($this->current_taxonomy['options']['qover'] == 'all') 
+				<input type="radio" name="se_cfg[<?php echo $taxonomy; ?>][options][qover]" value="all"
+					<?php if ($this->current_taxonomy['options']['qover'] == 'all')
 						echo "checked='checked'"; ?> /> <?php _e('All Loops', SIMPLY_EXCLUDE_I18N_DOMAIN); ?>
 			</td>
 		</tr>
@@ -676,7 +676,7 @@ class SimplyExclude
 			return;
 
 		$this->current_post_type = $this->se_cfg['data']['post_types'][$post_type];
-		
+
 		?>
 		<table class="widefat simply-exclude-settings-postbox simplyexclude-active-panel" cellpadding="3" cellspacing="3" border="0">
 		<thead>
@@ -691,18 +691,18 @@ class SimplyExclude
 				<p><?php _e("The Simply-Exclude plugin was designed to only work with the main page query. But sometimes other plugins or your theme will effect how the main filtering works. So if you are having trouble attempting to filter categories from your home page you might want to try and set this option to 'All' and see if it corrects your issue.", SIMPLY_EXCLUDE_I18N_DOMAIN); ?></p>
 			</td>
 			<td class="inc-excl">
-				<input type="radio" name="se_cfg[<?php echo $post_type; ?>][options][qover]" value="main" 
-					<?php if ($this->current_post_type['options']['qover'] == 'main') 
+				<input type="radio" name="se_cfg[<?php echo $post_type; ?>][options][qover]" value="main"
+					<?php if ($this->current_post_type['options']['qover'] == 'main')
 						echo "checked='checked'"; ?> /> <?php _e('Main Loop Only', SIMPLY_EXCLUDE_I18N_DOMAIN); ?><br />
-				<input type="radio" name="se_cfg[<?php echo $post_type; ?>][options][qover]" value="all" 
-					<?php if ($this->current_post_type['options']['qover'] == 'all') 
+				<input type="radio" name="se_cfg[<?php echo $post_type; ?>][options][qover]" value="all"
+					<?php if ($this->current_post_type['options']['qover'] == 'all')
 						echo "checked='checked'"; ?> /> <?php _e('All Loops', SIMPLY_EXCLUDE_I18N_DOMAIN); ?>
 			</td>
 		</tr>
 		</table>
 		<?php
 	}
-	
+
 	function se_show_se_type_query_override_panel($se_type)
 	{
 		if (!$se_type)	return;
@@ -711,7 +711,7 @@ class SimplyExclude
 			return;
 
 		$this->current_se_type = $this->se_cfg['data']['se_types'][$se_type];
-		
+
 		?>
 		<table class="widefat simply-exclude-settings-postbox simplyexclude-active-panel" cellpadding="3" cellspacing="3" border="0">
 		<thead>
@@ -726,28 +726,28 @@ class SimplyExclude
 				<p><?php _e("The Simply-Exclude plugin was designed to only work with the main page query. But sometimes other plugins or your theme will effect how the main filtering works. So if you are having trouble attempting to filter categories from your home page you might want to try and set this option to 'All' and see if it corrects your issue.", SIMPLY_EXCLUDE_I18N_DOMAIN); ?></p>
 			</td>
 			<td class="inc-excl">
-				<input type="radio" name="se_cfg[<?php echo $se_type; ?>][options][qover]" value="main" 
-					<?php if ($this->current_se_type['options']['qover'] == 'main') 
+				<input type="radio" name="se_cfg[<?php echo $se_type; ?>][options][qover]" value="main"
+					<?php if ($this->current_se_type['options']['qover'] == 'main')
 						echo "checked='checked'"; ?> /> <?php _e('Main Loop Only', SIMPLY_EXCLUDE_I18N_DOMAIN); ?><br />
-				<input type="radio" name="se_cfg[<?php echo $se_type; ?>][options][qover]" value="all" 
-					<?php if ($this->current_se_type['options']['qover'] == 'all') 
+				<input type="radio" name="se_cfg[<?php echo $se_type; ?>][options][qover]" value="all"
+					<?php if ($this->current_se_type['options']['qover'] == 'all')
 						echo "checked='checked'"; ?> /> <?php _e('All Loops', SIMPLY_EXCLUDE_I18N_DOMAIN); ?>
 			</td>
 		</tr>
 		</table>
 		<?php
 	}
-	
+
 	/****************************************************************************************************************************/
 	/*																															*/
 	/*												COLUMNS (HEADERS)															*/
 	/*																															*/
 	/****************************************************************************************************************************/
-		
+
 	function se_manage_taxonomy_columns($columns)
 	{
-		if (current_user_can('manage_options')) {		
-			if (!isset($columns['se-actions']))	
+		if (current_user_can('manage_options')) {
+			if (!isset($columns['se-actions']))
 				$columns['se-actions'] = '<a id="se-show-actions-panel" title="" href="#">'. __('Simply Exclude', SIMPLY_EXCLUDE_I18N_DOMAIN) .'</a>';
 		}
 		return $columns;
@@ -755,8 +755,8 @@ class SimplyExclude
 
 	function se_manage_post_type_columns($columns)
 	{
-		if (current_user_can('manage_options')) {			
-			if (!isset($columns['se_actions']))	
+		if (current_user_can('manage_options')) {
+			if (!isset($columns['se_actions']))
 				$columns['se-actions'] = __('Simply Exclude', SIMPLY_EXCLUDE_I18N_DOMAIN). ' <a id="se-show-actions-panel" href="#">'. __('show', SIMPLY_EXCLUDE_I18N_DOMAIN) .'</a>';
 		}
 		return $columns;
@@ -764,10 +764,10 @@ class SimplyExclude
 
 	function se_manage_user_columns($columns)
 	{
-		if (current_user_can('manage_options')) {			
-			if (!isset($columns['se_actions']))	
+		if (current_user_can('manage_options')) {
+			if (!isset($columns['se_actions']))
 				$columns['se-actions'] = __('Simply Exclude', SIMPLY_EXCLUDE_I18N_DOMAIN). ' <a id="se-show-actions-panel" href="#">'. __('show', SIMPLY_EXCLUDE_I18N_DOMAIN) .'</a>';
-		}		
+		}
 		return $columns;
 	}
 
@@ -781,8 +781,8 @@ class SimplyExclude
 	function se_display_taxonomy_column_filters($content='', $column_name, $term_id)
 	{
 		global $taxonomy, $post_type;
-		
-		if (current_user_can('manage_options')) {			
+
+		if (current_user_can('manage_options')) {
 			if ($column_name == "se-actions")
 			{
 				if ($taxonomy)
@@ -792,7 +792,7 @@ class SimplyExclude
 					{
 						$this->current_taxonomy = $this->se_cfg['data']['taxonomies'][$taxonomy];
 
-						ob_start();		
+						ob_start();
 						$this->se_display_taxonomy_term_action_row($taxonomy, $term);
 						$out = ob_get_contents();
 						ob_end_clean();
@@ -803,12 +803,12 @@ class SimplyExclude
 		}
 		return $content;
 	}
-	
+
 	function se_display_post_type_column_actions($column_name, $post_id)
 	{
 		global $post_type;
 
-		if (current_user_can('manage_options')) {			
+		if (current_user_can('manage_options')) {
 			if ($column_name == "se-actions")
 			{
 				$this->current_post_type = $this->se_cfg['data']['post_types'][$post_type];
@@ -817,30 +817,30 @@ class SimplyExclude
 				{
 					$p_item = get_post( $post_id );
 					if ($p_item)
-					{				
+					{
 						$this->se_display_post_type_action_row($post_type, $p_item);
 					}
 				}
 			}
 		}
 	}
-	
+
 	function se_display_user_column_actions($content='', $column_name, $user_id )
-	{	
-		if (current_user_can('manage_options')) {						
+	{
+		if (current_user_can('manage_options')) {
 			if ($column_name == "se-actions")
 			{
 				$se_type = "users";
 				if (isset($this->se_cfg['data']['se_types'][$se_type]))
 				{
-					ob_start();		
+					ob_start();
 
 					$this->current_se_type = $this->se_cfg['data']['se_types'][$se_type];
 					if ($user_id)
 					{
 						$user = get_userdata($user_id);
 						if ($user)
-						{				
+						{
 							$this->se_display_user_action_row($se_type, $user);
 						}
 					}
@@ -853,37 +853,37 @@ class SimplyExclude
 		}
 		return $content;
 	}
-	
-	
+
+
 	/****************************************************************************************************************************/
 	/*																															*/
 	/*												COLUMNS ACTION ROW															*/
 	/*																															*/
 	/****************************************************************************************************************************/
-	
+
 	function se_display_taxonomy_term_action_row($taxonomy='', $term='')
 	{
 		if (!$taxonomy) return;
 		if (!$term) return;
-		
-		if (current_user_can('manage_options')) {			
-		
+
+		if (current_user_can('manage_options')) {
+
 			if ((isset($this->current_taxonomy['actions'])) && (count($this->current_taxonomy['actions'])))
 			{
 				?><ul class="se-actions-list"><?php
 				foreach ($this->current_taxonomy['actions'] as $action_key => $action_val)
 				{
 					?>
-					<li><input type="checkbox" 
+					<li><input type="checkbox"
 						name="se_cfg[<?php echo $taxonomy; ?>][terms][<?php echo $action_key ?>][<?php echo $term->term_id ?>]"
 						id="<?php echo $taxonomy; ?>-<?php echo $action_key ?>-<?php echo $term->term_id ?>" class="se-term-input"
 						<?php
-							if ((isset($this->current_taxonomy['terms'][$action_key][$term->term_id])) 
+							if ((isset($this->current_taxonomy['terms'][$action_key][$term->term_id]))
 						 	 && ($this->current_taxonomy['terms'][$action_key][$term->term_id] == "on"))
 								echo "checked='checked' ";
-						?> />&nbsp;<label for="<?php echo $taxonomy; ?>-<?php echo $action_key ?>-<?php echo $term->term_id ?>" 
+						?> />&nbsp;<label for="<?php echo $taxonomy; ?>-<?php echo $action_key ?>-<?php echo $term->term_id ?>"
 							class="se-term-label"><?php echo $this->get_taxonomy_action_label($taxonomy, $action_key, 'name'); ?></label></li>
-										
+
 					<?php
 				}
 				?></ul><?php
@@ -896,19 +896,19 @@ class SimplyExclude
 		if (!$post_type) return;
 		if (!$p_item) return;
 
-		if (current_user_can('manage_options')) {			
+		if (current_user_can('manage_options')) {
 
 			if ((isset($this->current_post_type['actions'])) && (count($this->current_post_type['actions'])))
 			{
 				?><ul class="se-actions-list"><?php
 				foreach ($this->current_post_type['actions'] as $action_key => $action_val)
 				{
-					?><li><input type="checkbox" 
+					?><li><input type="checkbox"
 						name="se_cfg[<?php echo $post_type; ?>][terms][<?php echo $action_key ?>][<?php echo $p_item->ID ?>]"
 						id="<?php echo $post_type; ?>-<?php echo $action_key ?>-<?php echo $p_item->ID ?>" class="se-term-input"
 						<?php
 
-						if ((isset($this->current_post_type['terms'][$action_key][$p_item->ID])) 
+						if ((isset($this->current_post_type['terms'][$action_key][$p_item->ID]))
 						 && ($this->current_post_type['terms'][$action_key][$p_item->ID] == "on"))
 							echo "checked='checked' ";
 						?> />&nbsp;<label for="<?php echo $post_type; ?>-<?php echo $action_key ?>-<?php echo $p_item->ID ?>">
@@ -920,25 +920,25 @@ class SimplyExclude
 			}
 		}
 	}
-	
+
 	function se_display_user_action_row($se_type, $user)
 	{
 		if (!$se_type) return;
 		if (!$user) return;
 
-		if (current_user_can('manage_options')) {			
+		if (current_user_can('manage_options')) {
 
 			if ((isset($this->current_se_type['actions'])) && (count($this->current_se_type['actions'])))
 			{
 				?><ul class="se-actions-list"><?php
 				foreach ($this->current_se_type['actions'] as $action_key => $action_val)
 				{
-					?><li><input type="checkbox" 
+					?><li><input type="checkbox"
 						name="se_cfg[<?php echo $se_type; ?>][terms][<?php echo $action_key ?>][<?php echo $user->ID ?>]"
 						id="<?php echo $se_type; ?>-<?php echo $action_key ?>-<?php echo $user->ID ?>" class="se-term-input"
 						<?php
 
-						if ((isset($this->current_se_type['terms'][$action_key][$user->ID])) 
+						if ((isset($this->current_se_type['terms'][$action_key][$user->ID]))
 						 && ($this->current_se_type['terms'][$action_key][$user->ID] == "on"))
 							echo "checked='checked' ";
 						?> />&nbsp;<label for="<?php echo $se_type; ?>-<?php echo $action_key ?>-<?php echo $user->ID ?>">
@@ -950,21 +950,21 @@ class SimplyExclude
 			}
 		}
 	}
-	
-	
-	
+
+
+
 	/****************************************************************************************************************************/
 	/*																															*/
 	/*												USER PROFILE																*/
 	/*																															*/
 	/****************************************************************************************************************************/
-	
+
 	function se_show_user_profile($profileuser)
 	{
 		$se_type = "users";
 		$this->current_se_type = $this->se_cfg['data']['se_types'][$se_type];
 
-		if (current_user_can('manage_options')) {			
+		if (current_user_can('manage_options')) {
 
 			if ($this->current_se_type['options']['showhide'] == "show") {
 				?>
@@ -973,22 +973,22 @@ class SimplyExclude
 					<th><label for="simply-exclude">Simply-Exclude</label></th>
 					<td class="cat-action"><?php $this->se_display_user_action_row('users', $profileuser) ?></td>
 				</tr>
-				</table>		
+				</table>
 				<?php
 			}
-		}		
+		}
 	}
-	
+
 	function se_save_user_profile($user_id)
 	{
 		if (!$user_id)
 			return;
-						
-		$this->se_load_config();				
-		
+
+		$this->se_load_config();
+
 		// First remove all traces of the post item in the actions
 		$se_type = "users";
-		
+
 		if ((isset($this->se_cfg['data']['se_types'][$se_type]['terms'])) && (count($this->se_cfg['data']['se_types'][$se_type]['terms'])))
 		{
 			foreach($this->se_cfg['data']['se_types'][$se_type]['terms'] as $cfg_action => $cfg_action_items)
@@ -1005,15 +1005,15 @@ class SimplyExclude
 
 		if (isset($_REQUEST['se_cfg']))
 		{
-			$se_cfg = $_REQUEST['se_cfg'];				
+			$se_cfg = $_REQUEST['se_cfg'];
 
-			// Now add back the items which were checked. 
+			// Now add back the items which were checked.
 			foreach($se_cfg as $se_type => $se_type_items)
-			{				
+			{
 				foreach($se_type_items as $term => $se_items)
 				{
 					foreach($se_items as $action => $action_items)
-					{						
+					{
 						foreach($action_items as $action_id => $action_val)
 						{
 							$this->se_cfg['data']['se_types'][$se_type][$term][$action][$action_id] = $action_val;
@@ -1022,22 +1022,22 @@ class SimplyExclude
 				}
 			}
 		}
-		$this->se_save_config();				
+		$this->se_save_config();
 	}
 
 
-	
+
 
 	/****************************************************************************************************************************/
 	/*																															*/
 	/*												POST DBX SIDEBAR FOR POST TYPES												*/
 	/*																															*/
 	/****************************************************************************************************************************/
-			
+
 	function show_post_type_exclude_sidebar_dbx()
 	{
 		global $post;
-		
+
 		if (isset($this->se_cfg['data']['post_types'][$post->post_type]))
 		{
 			$this->current_post_type = $this->se_cfg['data']['post_types'][$post->post_type];
@@ -1049,15 +1049,15 @@ class SimplyExclude
 	{
 		if (!$post_id)
 			return;
-			
-		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) 
+
+		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE )
 			return;
 
-		if ( wp_is_post_revision( $post_id ) ) 
+		if ( wp_is_post_revision( $post_id ) )
 			return;
-			
-		$this->se_load_config();				
-		
+
+		$this->se_load_config();
+
 		if( (isset($_REQUEST['post_type'])) && (isset($_REQUEST['post_ID'])))
 		{
 			// First remove all traces of the post item in the actions
@@ -1078,15 +1078,15 @@ class SimplyExclude
 
 			if (isset($_REQUEST['se_cfg']))
 			{
-				$se_cfg = $_REQUEST['se_cfg'];				
-				
-				// Now add back the items which were checked. 
+				$se_cfg = $_REQUEST['se_cfg'];
+
+				// Now add back the items which were checked.
 				foreach($se_cfg as $post_type => $post_type_items)
-				{				
+				{
 					foreach($post_type_items as $term => $term_items)
 					{
 						foreach($term_items as $action => $action_items)
-						{						
+						{
 							foreach($action_items as $action_id => $action_val)
 							{
 								$this->se_cfg['data']['post_types'][$post_type][$term][$action][$action_id] = $action_val;
@@ -1096,7 +1096,7 @@ class SimplyExclude
 				}
 			}
 		}
-		$this->se_save_config();				
+		$this->se_save_config();
 	}
 
 
@@ -1113,12 +1113,12 @@ class SimplyExclude
 	{
 		if (!isset($_REQUEST['tag_ID']))
 			return;
-		
-		if (!isset($_REQUEST['taxonomy']))	
+
+		if (!isset($_REQUEST['taxonomy']))
 			return;
-		
+
 		$this->se_load_config();
-			
+
 		$this->current_taxonomy = $this->se_cfg['data']['taxonomies'][$_REQUEST['taxonomy']];
 		$term = get_term_by("ID", $_REQUEST['tag_ID'], $_REQUEST['taxonomy']);
 		?>
@@ -1132,8 +1132,8 @@ class SimplyExclude
 
 	function se_save_taxonomy_term_fields($term_id, $tt_id, $taxonomy)
 	{
-		$this->se_load_config();				
-		
+		$this->se_load_config();
+
 		if ((isset($taxonomy)) && (isset($term_id)))
 		{
 			// First remove all traces of the taxonomy item in the actions
@@ -1153,13 +1153,13 @@ class SimplyExclude
 			{
 				$se_cfg = $_REQUEST['se_cfg'];
 
-				// Now add back the items which were checked. 
+				// Now add back the items which were checked.
 				foreach($se_cfg as $taxonomy => $taxonomy_items)
-				{				
+				{
 					foreach($taxonomy_items as $term => $term_items)
 					{
 						foreach($term_items as $action => $action_items)
-						{						
+						{
 							foreach($action_items as $action_id => $action_val)
 							{
 								$this->se_cfg['data']['taxonomies'][$taxonomy][$term][$action][$action_id] = $action_val;
@@ -1168,7 +1168,7 @@ class SimplyExclude
 					}
 				}
 			}
-			$this->se_save_config();				
+			$this->se_save_config();
 		}
 	}
 
@@ -1180,9 +1180,9 @@ class SimplyExclude
 	/****************************************************************************************************************************/
 
 	function se_load_config()
-	{		
+	{
 		$tmp_se_cfg = get_option($this->options_key);
-		
+
 		if (!$tmp_se_cfg)
 		{
 			$tmp_se_cfg = $this->se_convert_configuration();
@@ -1196,7 +1196,7 @@ class SimplyExclude
 
 //			if (!isset($this->se_cfg['cfg']['version']))
 //				$this->se_cfg['cfg']['version'] = $this->se_version;
-		}	
+		}
 		$this->se_cfg['cfg']['version'] = $this->se_version;
 
 		$se_taxonomies = $this->se_load_taxonomy_list();
@@ -1206,35 +1206,35 @@ class SimplyExclude
 			{
 				if (!isset($this->se_cfg['data']['taxonomies'][$t_item->name]['actions']))
 					$this->se_cfg['data']['taxonomies'][$t_item->name]['actions'] = array();
-					
+
 				$default_actions = $this->se_load_taxonomy_default_actions($t_item->name);
 				if ($default_actions)
 				{
-					$this->se_cfg['data']['taxonomies'][$t_item->name]['actions'] = array_merge($default_actions, 
+					$this->se_cfg['data']['taxonomies'][$t_item->name]['actions'] = array_merge($default_actions,
 						$this->se_cfg['data']['taxonomies'][$t_item->name]['actions']);
 				}
 
 				ksort($this->se_cfg['data']['taxonomies'][$t_item->name]['actions']);
-				
+
 				if (!isset($this->se_cfg['data']['taxonomies'][$t_item->name]['options']))
 					$this->se_cfg['data']['taxonomies'][$t_item->name]['options'] = array();
-					
+
 				if (!isset($this->se_cfg['data']['taxonomies'][$t_item->name]['options']['active']))
 					$this->se_cfg['data']['taxonomies'][$t_item->name]['options']['active'] = 'yes';
 
 				if (!isset($this->se_cfg['data']['taxonomies'][$t_item->name]['options']['showhide']))
-					$this->se_cfg['data']['taxonomies'][$t_item->name]['options']['showhide'] = 'show';				
+					$this->se_cfg['data']['taxonomies'][$t_item->name]['options']['showhide'] = 'show';
 
 				if ($this->se_cfg['data']['taxonomies'][$t_item->name]['options']['showhide'] == "yes")
-					$this->se_cfg['data']['taxonomies'][$t_item->name]['options']['showhide'] = 'show';				
+					$this->se_cfg['data']['taxonomies'][$t_item->name]['options']['showhide'] = 'show';
 				else if ($this->se_cfg['data']['taxonomies'][$t_item->name]['options']['showhide'] == "no")
 					$this->se_cfg['data']['taxonomies'][$t_item->name]['options']['showhide'] = 'hide';
-				
+
 				if (!isset($this->se_cfg['data']['taxonomies'][$t_item->name]['options']['qover']))
-					$this->se_cfg['data']['taxonomies'][$t_item->name]['options']['qover'] = 'main';				
+					$this->se_cfg['data']['taxonomies'][$t_item->name]['options']['qover'] = 'main';
 
 				$this->se_cfg['data']['taxonomies'][$t_item->name]['options']['hierarchical'] = $t_item->hierarchical;
-					
+
 			}
 		}
 
@@ -1245,11 +1245,11 @@ class SimplyExclude
 			{
 				if (!isset($this->se_cfg['data']['post_types'][$t_item->name]['actions']))
 					$this->se_cfg['data']['post_types'][$t_item->name]['actions'] = array();
-					
+
 				$actions = $this->se_load_post_type_default_actions($t_item->name);
 				if ($actions)
 				{
-					$this->se_cfg['data']['post_types'][$t_item->name]['actions'] = array_merge($actions, 
+					$this->se_cfg['data']['post_types'][$t_item->name]['actions'] = array_merge($actions,
 						$this->se_cfg['data']['post_types'][$t_item->name]['actions']);
 				}
 
@@ -1262,16 +1262,16 @@ class SimplyExclude
 					$this->se_cfg['data']['post_types'][$t_item->name]['options']['active'] = 'yes';
 
 				if (!isset($this->se_cfg['data']['post_types'][$t_item->name]['options']['showhide']))
-					$this->se_cfg['data']['post_types'][$t_item->name]['options']['showhide'] = 'show';						
+					$this->se_cfg['data']['post_types'][$t_item->name]['options']['showhide'] = 'show';
 
 				if ($this->se_cfg['data']['post_types'][$t_item->name]['options']['showhide'] == "yes")
-					$this->se_cfg['data']['post_types'][$t_item->name]['options']['showhide'] = 'show';				
+					$this->se_cfg['data']['post_types'][$t_item->name]['options']['showhide'] = 'show';
 				else if ($this->se_cfg['data']['post_types'][$t_item->name]['options']['showhide'] == "no")
 					$this->se_cfg['data']['post_types'][$t_item->name]['options']['showhide'] = 'hide';
-				
+
 				if (!isset($this->se_cfg['data']['post_types'][$t_item->name]['options']['qover']))
-					$this->se_cfg['data']['post_types'][$t_item->name]['options']['qover'] = 'main';						
-				
+					$this->se_cfg['data']['post_types'][$t_item->name]['options']['qover'] = 'main';
+
 				$this->se_cfg['data']['post_types'][$t_item->name]['options']['capability_type'] = $t_item->capability_type;
 			}
 		}
@@ -1283,11 +1283,11 @@ class SimplyExclude
 			{
 				if (!isset($this->se_cfg['data']['se_types'][$t_item['name']]['actions']))
 					$this->se_cfg['data']['se_types'][$t_item['name']]['actions'] = array();
-					
+
 				$actions = $this->se_load_se_type_default_actions($t_item['name']);
 				if ($actions)
 				{
-					$this->se_cfg['data']['se_types'][$t_item['name']]['actions'] = array_merge($actions, 
+					$this->se_cfg['data']['se_types'][$t_item['name']]['actions'] = array_merge($actions,
 						$this->se_cfg['data']['se_types'][$t_item['name']]['actions']);
 				}
 
@@ -1298,15 +1298,15 @@ class SimplyExclude
 					$this->se_cfg['data']['se_types'][$t_item['name']]['options']['active'] = 'yes';
 
 				if (!isset($this->se_cfg['data']['se_types'][$t_item['name']]['options']['showhide']))
-					$this->se_cfg['data']['se_types'][$t_item['name']]['options']['showhide'] = 'show';						
+					$this->se_cfg['data']['se_types'][$t_item['name']]['options']['showhide'] = 'show';
 
 				if ($this->se_cfg['data']['se_types'][$t_item['name']]['options']['showhide'] == "yes")
-					$this->se_cfg['data']['se_types'][$t_item['name']]['options']['showhide'] = 'show';				
+					$this->se_cfg['data']['se_types'][$t_item['name']]['options']['showhide'] = 'show';
 				else if ($this->se_cfg['data']['se_types'][$t_item['name']]['options']['showhide'] == "no")
 					$this->se_cfg['data']['se_types'][$t_item['name']]['options']['showhide'] = 'hide';
 
 				if (!isset($this->se_cfg['data']['se_types'][$t_item['name']]['options']['qover']))
-					$this->se_cfg['data']['se_types'][$t_item['name']]['options']['qover'] = 'main';						
+					$this->se_cfg['data']['se_types'][$t_item['name']]['options']['qover'] = 'main';
 			}
 		}
 
@@ -1315,7 +1315,7 @@ class SimplyExclude
 			$this->se_cfg['options'] 									= array();
 /*
 		$this->se_cfg['options']['plugins'] 							= array();
-		
+
 		$this->se_cfg['options']['plugins']['google-sitemap-generator'] 				= array();
 		$this->se_cfg['options']['plugins']['google-sitemap-generator']['name'] 		= __("Google XML Sitemaps", SIMPLY_EXCLUDE_I18N_DOMAIN);
 		$this->se_cfg['options']['plugins']['google-sitemap-generator']['url'] 			= "http://wordpress.org/extend/plugins/google-sitemap-generator/";
@@ -1323,14 +1323,14 @@ class SimplyExclude
 		$this->se_cfg['options']['plugins']['google-sitemap-generator']['version'] 		= "3.1.6";
 		$this->se_cfg['options']['plugins']['google-sitemap-generator']['active'] 		= false;
 		$this->se_cfg['options']['plugins']['google-sitemap-generator']['plugin_key'] 	= "google-sitemap-generator/sitemap.php";
-			
+
 		$this->se_cfg['options']['plugins']['google-sitemap-generator']['actions'] 							= array();
-		$this->se_cfg['options']['plugins']['google-sitemap-generator']['actions']['pages']['desc'] 		= __("Update Excluded Pages", SIMPLY_EXCLUDE_I18N_DOMAIN);		
-		$this->se_cfg['options']['plugins']['google-sitemap-generator']['actions']['pages']['update'] 		= false;		
-		$this->se_cfg['options']['plugins']['google-sitemap-generator']['actions']['categories']['desc'] 	= __("Update Excluded Categories", SIMPLY_EXCLUDE_I18N_DOMAIN);		
-		$this->se_cfg['options']['plugins']['google-sitemap-generator']['actions']['categories']['update'] 	= false;		
-		
-		
+		$this->se_cfg['options']['plugins']['google-sitemap-generator']['actions']['pages']['desc'] 		= __("Update Excluded Pages", SIMPLY_EXCLUDE_I18N_DOMAIN);
+		$this->se_cfg['options']['plugins']['google-sitemap-generator']['actions']['pages']['update'] 		= false;
+		$this->se_cfg['options']['plugins']['google-sitemap-generator']['actions']['categories']['desc'] 	= __("Update Excluded Categories", SIMPLY_EXCLUDE_I18N_DOMAIN);
+		$this->se_cfg['options']['plugins']['google-sitemap-generator']['actions']['categories']['update'] 	= false;
+
+
 		$this->se_cfg['options']['plugins']['search-unleashed']						= array();
 		$this->se_cfg['options']['plugins']['search-unleashed']['name']				= __("Search Unleashed", SIMPLY_EXCLUDE_I18N_DOMAIN);
 		$this->se_cfg['options']['plugins']['search-unleashed']['url']				= "http://wordpress.org/extend/plugins/search-unleashed/";
@@ -1338,27 +1338,27 @@ class SimplyExclude
 		$this->se_cfg['options']['plugins']['search-unleashed']['version']			= "1.0.5";
 		$this->se_cfg['options']['plugins']['search-unleashed']['active']			= false;
 		$this->se_cfg['options']['plugins']['search-unleashed']['plugin_key'] 		= "search-unleashed/search-unleashed.php";
-			
+
 		$this->se_cfg['options']['plugins']['search-unleashed']['actions'] 							= array();
 		$this->se_cfg['options']['plugins']['search-unleashed']['actions']['pages']['desc'] 		= __("Update Excluded Pages", SIMPLY_EXCLUDE_I18N_DOMAIN);
 		$this->se_cfg['options']['plugins']['search-unleashed']['actions']['pages']['update'] 		= false;
 		$this->se_cfg['options']['plugins']['search-unleashed']['actions']['categories']['desc'] 	= __("Update Excluded Categories", SIMPLY_EXCLUDE_I18N_DOMAIN);
-		$this->se_cfg['options']['plugins']['search-unleashed']['actions']['categories']['update'] 	= false;				
+		$this->se_cfg['options']['plugins']['search-unleashed']['actions']['categories']['update'] 	= false;
 		$this->se_cfg['options']['plugins']['search-unleashed']['desc']								= __("Warning: Page ID listed in the Search Unleashed plugin will be removed and replaced with Page ID from the Simply Exclude plugin. Post ID values will be ignored", SIMPLY_EXCLUDE_I18N_DOMAIN);
-		
+
 		foreach($this->se_cfg['options']['plugins'] as $plugin => $plugin_data)
 		{
 			if ((isset($plugin_data['plugin_key'])) && (strlen($plugin_data['plugin_key'])))
 			{
-				if ($this->is_plugin_active($plugin_data['plugin_key'])) 
+				if ($this->is_plugin_active($plugin_data['plugin_key']))
 				{
 					$this->se_cfg['options']['plugins'][$plugin]['active'] = true;
 				}
 			}
 		}
-*/		
-	}	
-	
+*/
+	}
+
 	function se_convert_configuration() {
 		$local_cfg = array();
 
@@ -1404,7 +1404,7 @@ class SimplyExclude
 						$local_cfg['data']['taxonomies']['category']['actions']['widget_category'] = "e";
 
 					if (isset($local_cfg['data']['taxonomies']['category']['terms']['is_archive']))
-						$local_cfg['data']['taxonomies']['category']['terms']['widget_category'] = $local_cfg['data']['taxonomies']['category']['terms']['is_archive'];							
+						$local_cfg['data']['taxonomies']['category']['terms']['widget_category'] = $local_cfg['data']['taxonomies']['category']['terms']['is_archive'];
 
 					unset($local_cfg['data']['taxonomies']['category']['wp_list_categories']);
 				}
@@ -1445,7 +1445,7 @@ class SimplyExclude
 						$local_cfg['data']['taxonomies']['post_tag']['actions']['widget_tag_cloud'] = "e";
 
 					if (isset($local_cfg['data']['taxonomies']['post_tag']['terms']['is_archive']))
-						$local_cfg['data']['taxonomies']['post_tag']['terms']['widget_tag_cloud'] = $local_cfg['data']['taxonomies']['post_tag']['terms']['is_archive'];							
+						$local_cfg['data']['taxonomies']['post_tag']['terms']['widget_tag_cloud'] = $local_cfg['data']['taxonomies']['post_tag']['terms']['is_archive'];
 
 					unset($local_cfg['data']['taxonomies']['post_tag']['wp_list_categories']);
 				}
@@ -1496,14 +1496,14 @@ class SimplyExclude
 			}
 		}
 
-		/*	
+		/*
 		if (isset($local_cfg['options']['google-sitemap-generator']))
 		{
 			$local_cfg['options']['plugins']['google-sitemap-generator'] = $local_cfg['options']['google-sitemap-generator'];
 			unset($local_cfg['options']['google-sitemap-generator']);
 
 			if (!isset($local_cfg['options']['plugins']['google-sitemap-generator']['plugin_key']))
-				$local_cfg['options']['plugins']['google-sitemap-generator']['plugin_key'] 	= "google-sitemap-generator/sitemap.php";				
+				$local_cfg['options']['plugins']['google-sitemap-generator']['plugin_key'] 	= "google-sitemap-generator/sitemap.php";
 		}
 
 		if (isset($local_cfg['options']['search-unleashed']))
@@ -1530,7 +1530,7 @@ class SimplyExclude
 			return in_array( $plugin, (array) get_option( 'active_plugins', array() ) ) || is_plugin_active_for_network( $plugin );
 		}
 	}
-	
+
 
 	function se_save_config()
 	{
@@ -1551,18 +1551,18 @@ class SimplyExclude
 			}
 		}
 	}
-*/	
-	
+*/
+
 	/****************************************************************************************************************************/
 	/*																															*/
 	/*												LOAD TYPES (TAX, POST, SE)													*/
 	/*																															*/
 	/****************************************************************************************************************************/
-	
+
 	function se_load_taxonomy_list()
 	{
 		$se_taxonomies = array();
-		
+
 		$taxonomies = get_taxonomies();
 		if ( $taxonomies )
 		{
@@ -1570,20 +1570,20 @@ class SimplyExclude
 			{
 				if (array_search($tax_item, $this->se_taxonomies_exclude) !== false)
 					continue;
-				
+
 				$tax_struct =  get_taxonomy($tax_item);
 				//echo "tax_struct<pre>"; print_r($tax_struct); echo "</pre>";
 				if ($tax_struct)
 				{
 					//$se_taxonomies[$tax_struct->labels->name] = $tax_struct;
 					$se_taxonomies[$tax_item] = $tax_struct;
-				}				
+				}
 			}
 		}
 		ksort($se_taxonomies);
 		return $se_taxonomies;
 	}
-	
+
 	function se_load_post_type_list()
 	{
 		$se_post_types = array();
@@ -1601,80 +1601,83 @@ class SimplyExclude
 				{
 					//$se_post_types[$post_type_struct->labels->name] = $post_type_struct;
 					$se_post_types[$post_type_item] = $post_type_struct;
-				}				
+				}
 			}
 		}
 		ksort($se_post_types);
 		return $se_post_types;
 	}
-	
+
 	function se_load_se_type_list()
 	{
 		$se_types['users'] = array(
 			'name'	=> 'users'
 		);
 
-		ksort($se_types);		
+		ksort($se_types);
 		return $se_types;
 	}
-	
-	
+
+
 	/****************************************************************************************************************************/
 	/*																															*/
 	/*												LOAD TYPE DEFAULT ACTIONS													*/
 	/*																															*/
 	/****************************************************************************************************************************/
-	
+
 	function se_load_taxonomy_default_actions($taxonomy)
 	{
 		if (!$taxonomy) return;
-		
+
 		$taxonomy_actions['is_home'] 				= "i";
 		$taxonomy_actions['is_archive'] 			= "e";
 		$taxonomy_actions['is_search'] 				= "e";
 		$taxonomy_actions['is_feed'] 				= "e";
-		
+
 		if ($taxonomy == "category")
 		{
-			$taxonomy_actions['widget_category'] 	= "e";			
-			$taxonomy_actions['widget_tag_cloud'] 	= "e";			
+			$taxonomy_actions['widget_category'] 	= "e";
+			$taxonomy_actions['widget_tag_cloud'] 	= "e";
 		}
 
 		if ($taxonomy == "post_tag")
 		{
-			$taxonomy_actions['widget_tag_cloud'] 	= "e";			
+			$taxonomy_actions['widget_tag_cloud'] 	= "e";
 		}
 
 		return $taxonomy_actions;
-	}	
+	}
 
 
 	function se_load_post_type_default_actions($post_type)
 	{
 		if (!$post_type) return;
-		
+
 		$taxonomy_actions = array();
-		
+
 		$post_type_object = get_post_type_object($post_type);
 
 		if ($post_type_object->capability_type == "post")
-		{			
+		{
 			$taxonomy_actions['is_home'] 			= "i";
 			$taxonomy_actions['is_archive'] 		= "e";
 			$taxonomy_actions['is_search'] 			= "e";
 			$taxonomy_actions['is_feed'] 			= "e";
 		}
 		else if ($post_type == "page")
-		{			
+		{
 			$taxonomy_actions['is_search'] 			= "e";
 			$taxonomy_actions['widget_pages'] 		= "e";
 		}
 		else
-		{		
+		{
+			$taxonomy_actions['is_home'] 			= "e";
+			$taxonomy_actions['is_archive'] 		= "e";
 			$taxonomy_actions['is_search'] 			= "e";
+			$taxonomy_actions['is_feed'] 			= "e";
 		}
 		return $taxonomy_actions;
-	}	
+	}
 
 
 	function se_load_se_type_default_actions()
@@ -1686,15 +1689,15 @@ class SimplyExclude
 
 		return $taxonomy_actions;
 	}
-	
-	
-	
+
+
+
 	/****************************************************************************************************************************/
 	/*																															*/
 	/*												ACTION LABELS																*/
 	/*																															*/
 	/****************************************************************************************************************************/
-	
+
 		function get_taxonomy_action_label($taxonomy, $action, $key)
 	{
 //		echo "taxonomy=[". $taxonomy ."]<br />";
@@ -1818,7 +1821,7 @@ class SimplyExclude
 			default:
 				return;
 				break;
-		}		
+		}
 	}
 
 	function get_post_type_action_label($post_type, $action, $key)
@@ -1915,9 +1918,9 @@ class SimplyExclude
 
 		}
 	}
-	
+
 	function get_se_type_action_label($se_type, $action, $key)
-	{		
+	{
 		switch($action)
 		{
 			case 'is_home':
@@ -1977,7 +1980,7 @@ class SimplyExclude
 			case 'is_feed':
 
 				switch($key)
-				{					
+				{
 					case 'name':
 						return __("Feeds", SIMPLY_EXCLUDE_I18N_DOMAIN);
 						break;
@@ -2004,8 +2007,8 @@ class SimplyExclude
 	/*												SE FILTER LOGIC																*/
 	/*																															*/
 	/****************************************************************************************************************************/
-	
-	function se_filters($query) 
+
+	function se_filters($query)
 	{
 		global $wp_version;
 
@@ -2021,53 +2024,53 @@ class SimplyExclude
 
 		// Normally we only want to handle the main page loop. But sometimes...
 		$is_main_query_loop = false;
-		
+
 		global $wp_the_query;
 		if ($wp_the_query === $query)
 			$is_main_query_loop = true;
 
 		if ( $se_debug == true ) {
-		
+
 			if ($is_main_query_loop == true)
 				echo "is_main_query_loop=[true]<br />";
 			else
 				echo "is_main_query_loop=[false]<br />";
 		}
-		
+
 		if (isset($query->query_vars['post_type'])) {
-		
+
 			if (array_search($query->query_vars['post_type'], $this->se_post_types_exclude) !== false)
 				return $query;
 		}
-		
-		
+
+
 		$this->se_load_config();
 
-			
+
 		$action_data = array();
 
 		// Only filter on our actions.
 		if (($query->is_home) || ($query->is_posts_page))
 		{
 			$action_data = $this->se_get_action_data('is_home');
-		} 
-		else if ($query->is_search) 
+		}
+		else if ($query->is_search)
 		{
 			$action_data = $this->se_get_action_data('is_search');
 		}
-		else if ($query->is_feed)  
+		else if ($query->is_feed)
 		{
 			$action_data = $this->se_get_action_data('is_feed');
 		}
-		else if ($query->is_archive)  
+		else if ($query->is_archive)
 		{
-			$action_data = $this->se_get_action_data('is_archive');			
+			$action_data = $this->se_get_action_data('is_archive');
 		}
 
 		if ( $se_debug == true ) {
 			echo "action_data<pre>"; print_r($action_data); echo "</pre>";
 		}
-		
+
 		if ($action_data)
 		{
 			$tax_query = array();
@@ -2081,7 +2084,7 @@ class SimplyExclude
 					{
 						if (($is_main_query_loop == false) && ($this->se_cfg['data']['taxonomies'][$key_key]['options']['qover'] == "main"))
 							continue;
-							
+
 						$tax_args = array(
 							'taxonomy' 	=> $key_key,
 							'field' 	=> 'id',
@@ -2110,14 +2113,14 @@ class SimplyExclude
 					$post__all = array();
 
 					foreach($key_data as $key_key => $key_key_data)
-					{						
+					{
 						if (($is_main_query_loop == false) && ($this->se_cfg['data']['post_types'][$key_key]['options']['qover'] == "main"))
 							continue;
 
 						if ($key_key_data['actions'] == 'e') {
 							$post__not_in = array_merge($post__not_in, $key_key_data['terms']);
 							$post_types_array['__not_in'][] = $key_key;
-							
+
 						} else if ($key_key_data['actions'] == 'i') {
 							$post__in = array_merge($post__in, $key_key_data['terms']);
 							$post_types_array['__in'][] = $key_key;
@@ -2142,7 +2145,7 @@ class SimplyExclude
 					{
 						$query_post_types = array($query_post_types);
 					}
-					
+
 					if ( $se_debug == true ) {
 						echo "query_post_types<pre>"; print_r($query_post_types); echo "</pre>";
 						echo "post_types_array<pre>"; print_r($post_types_array); echo "</pre>";
@@ -2154,28 +2157,28 @@ class SimplyExclude
 					if (count($post__not_in))
 					{
 						$query->set('post__not_in', $post__not_in);
-						
+
 						if ( $se_debug == true ) {
-							
+
 							echo "PROCESSING: POST__NOT_IN<br />";
 							echo "post__not_in<pre>"; print_r($post__not_in); echo "</pre>";
-						}						
+						}
 					}
 					else if (count($post__in))
 					{
 						$query->set('post__in', $post__in);
-						
+
 						if (isset($post_types_array['__in']))
 						{
 							$merged_query_post_types = array_unique(array_merge($post_types_array['__in'], $query_post_types));
 							$query->set('post_type', $merged_query_post_types);
-						}						
+						}
 						if ( $se_debug == true ) {
 							echo "PROCESSING: POST__IN<br />";
 							echo "post__in<pre>"; print_r($post__in); echo "</pre>";
 							echo "merged_query_post_types<pre>"; print_r($merged_query_post_types); echo "</pre>";
 						}
-					} 
+					}
 					else if ((isset($post_types_array['all'])) && (count($post_types_array['all'])))
 					{
 						$merged_query_post_types = array_unique(array_merge($post_types_array['all'], $query_post_types));
@@ -2185,7 +2188,7 @@ class SimplyExclude
 							echo "merged_query_post_types<pre>"; print_r($merged_query_post_types); echo "</pre>";
 						}
 						$query->set('post_type', $merged_query_post_types);
-					} 
+					}
 				}
 				else if ($key == "se_types")
 				{
@@ -2193,7 +2196,7 @@ class SimplyExclude
 					{
 						if (($is_main_query_loop == false) && ($this->se_cfg['data']['se_types'][$key_key]['options']['qover'] == "main"))
 							continue;
-						
+
 						if ($key_key == "users")
 						{
 							$user_ids = $this->se_listify_ids($key_key_data['terms'], $key_key_data['actions']);
@@ -2203,10 +2206,10 @@ class SimplyExclude
 
 								if ( $se_debug == true ) {
 									echo "user_ids=[". $user_ids ."]<br />";
-								}								
+								}
 							}
 						}
-					}					
+					}
 				}
 			}
 			if (count($tax_query))
@@ -2236,7 +2239,7 @@ class SimplyExclude
 
 		$action_data = array();
 		//echo "action=[". $action ."]<br />";
-		
+
 		//echo "se_cfg taxonomies<pre>"; print_r($this->se_cfg['data']['taxonomies']); echo "</pre>";
 		foreach($this->se_cfg['data']['taxonomies'] as $key => $data)
 		{
@@ -2248,9 +2251,9 @@ class SimplyExclude
 
 				foreach($data['terms'][$action] as $id => $val)
 				{
-					$action_data['taxonomies'][$key]['terms'][] 		= $id;				
+					$action_data['taxonomies'][$key]['terms'][] 		= $id;
 				}
-				$action_data['taxonomies'][$key]['actions'] 	= $data['actions'][$action];			
+				$action_data['taxonomies'][$key]['actions'] 	= $data['actions'][$action];
 			}
 		}
 
@@ -2270,10 +2273,10 @@ class SimplyExclude
 
 				foreach($data['terms'][$action] as $id => $val)
 				{
-					$action_data['post_types'][$key]['terms'][] 		= $id;				
+					$action_data['post_types'][$key]['terms'][] 		= $id;
 				}
 
-				$action_data['post_types'][$key]['actions'] 	= $data['actions'][$action];			
+				$action_data['post_types'][$key]['actions'] 	= $data['actions'][$action];
 			}
 		}
 
@@ -2287,24 +2290,24 @@ class SimplyExclude
 
 				foreach($data['terms'][$action] as $id => $val)
 				{
-					$action_data['se_types'][$key]['terms'][] 		= $id;				
+					$action_data['se_types'][$key]['terms'][] 		= $id;
 				}
 
-				$action_data['se_types'][$key]['actions'] 	= $data['actions'][$action];			
+				$action_data['se_types'][$key]['actions'] 	= $data['actions'][$action];
 			}
-			
+
 		}
-		//echo "action_data<pre>"; print_r($action_data); echo "</pre>";		
+		//echo "action_data<pre>"; print_r($action_data); echo "</pre>";
 		return $action_data;
 	}
-	
-	
-	
-	
-	
-	
-	
-	
+
+
+
+
+
+
+
+
 	/****************************************************************************************************************************/
 	/*																															*/
 	/*												WIDGET FILTER LOGIC															*/
@@ -2314,7 +2317,7 @@ class SimplyExclude
 	function se_widget_pages_args_proc($args)
 	{
 		//echo "args<pre>"; print_r($args); echo "</pre>";
-		
+
 		if (isset($args['exclude']))
 		{
 			if ((is_array($args['exclude'])) && (count($args['exclude'])))
@@ -2330,7 +2333,7 @@ class SimplyExclude
 			else if (strlen($args['include']))
 				return $args;
 		}
-					
+
 		$this->se_load_config();
 
 //		echo "se_cfg<pre>"; print_r($this->se_cfg['data']['post_types']['page']); echo "</pre>";
@@ -2345,21 +2348,21 @@ class SimplyExclude
 			if ($action == "e")
 				$args['exclude'] = $terms;
 			else if ($action == 'i')
-				$args['include'] = $terms;			
+				$args['include'] = $terms;
 		}
 		//echo "args AFTER<pre>"; print_r($args); echo "</pre>";
 		return $args;
 	}
-		
+
 	function se_widget_categories_dropdown_args_proc($args)
 	{
 		if ((isset($args['include'])) || (isset($args['exclude'])))
 			return;
-			
+
 		$this->se_load_config();
-		
+
 		//echo "widget_category<pre>"; print_r($this->se_cfg['data']['taxonomies']['category']['terms']['widget_category']); echo "</pre>";
-		
+
 		if ( (isset($this->se_cfg['data']['taxonomies']['category']['terms']['widget_category']))
 		  && (count($this->se_cfg['data']['taxonomies']['category']['terms']['widget_category'])) )
 		{
@@ -2368,11 +2371,11 @@ class SimplyExclude
 
 			$all_cat_ids = array();
 
-			if ($action == 'e') 
+			if ($action == 'e')
 			{
 				$all_cat_ids = array_keys($terms);
 			}
-			else if ($action == 'i') 
+			else if ($action == 'i')
 			{
 				$all_cat_ids = get_all_category_ids();
 				if (!$all_cat_ids)
@@ -2385,7 +2388,7 @@ class SimplyExclude
 						unset($all_cat_ids[$item_idx]);
 				}
 			}
-			
+
 			if ((isset($all_cat_ids)) && (count($all_cat_ids)))
 			{
 				$args['exclude'] = implode(',', $all_cat_ids);
@@ -2393,32 +2396,32 @@ class SimplyExclude
 		}
 		return $args;
 	}
-	
-	// The tag Cloud widget now supports using either taxonomy (post_tag or category). 
+
+	// The tag Cloud widget now supports using either taxonomy (post_tag or category).
 	function se_widget_tag_cloud_args_proc($args)
 	{
 		if ((isset($args['include'])) || (isset($args['exclude'])))
 			return $args;
-		
+
 		if (!isset($args['taxonomy']))
 			return $args;
-			
-		if ( ($args['taxonomy'] != "category") && ($args['taxonomy'] != "post_tag") ) 
+
+		if ( ($args['taxonomy'] != "category") && ($args['taxonomy'] != "post_tag") )
 			return $args;
-			
+
 		$this->se_load_config();
-		
+
 		switch ($args['taxonomy'])
 		{
 			case 'post_tag':
-			
+
 				if ( (isset($this->se_cfg['data']['taxonomies']['post_tag']['terms']['widget_tag_cloud']))
 				  && (count($this->se_cfg['data']['taxonomies']['post_tag']['terms']['widget_tag_cloud'])) )
 				{
 					$action = $this->se_cfg['data']['taxonomies']['post_tag']['actions']['widget_tag_cloud'];
 					$terms 	= $this->se_cfg['data']['taxonomies']['post_tag']['terms']['widget_tag_cloud'];
 
-					$all_tags = get_tags('hide_empty=0&orderby=name&order=ASC');			
+					$all_tags = get_tags('hide_empty=0&orderby=name&order=ASC');
 					$all_tag_ids = array();
 					if ($all_tags)
 					{
@@ -2426,15 +2429,15 @@ class SimplyExclude
 						{
 							$all_tag_ids[] = $t_item->term_id;
 						}
-					}			
+					}
 
 					if (count($all_tag_ids))
 					{
-						if ($action == 'e') 
+						if ($action == 'e')
 						{
 							$all_tag_ids = array_keys($terms);
 						}
-						else if ($action == 'i') 
+						else if ($action == 'i')
 						{
 							foreach($terms as $c_idx => $c_item)
 							{
@@ -2449,9 +2452,9 @@ class SimplyExclude
 							$args['exclude'] = implode(',', $all_tag_ids);
 						}
 					}
-				}				
+				}
 				break;
-				
+
 			case 'category':
 				if ( (isset($this->se_cfg['data']['taxonomies']['category']['terms']['widget_tag_cloud']))
 				  && (count($this->se_cfg['data']['taxonomies']['category']['terms']['widget_tag_cloud'])) )
@@ -2461,11 +2464,11 @@ class SimplyExclude
 
 					$all_cat_ids = array();
 
-					if ($action == 'e') 
+					if ($action == 'e')
 					{
 						$all_cat_ids = array_keys($terms);
 					}
-					else if ($action == 'i') 
+					else if ($action == 'i')
 					{
 						$all_cat_ids = get_all_category_ids();
 						if (!$all_cat_ids)
@@ -2484,25 +2487,25 @@ class SimplyExclude
 						$args['exclude'] = implode(',', $all_cat_ids);
 					}
 				}
-				
+
 				break;
-				
+
 			default:
 				break;
-				
+
 		}
 		return $args;
 	}
-	
-	
-	
-		
+
+
+
+
 	function se_admin_footer()
 	{
 		if ( !current_user_can('manage_options') )
 			return;
 
-		if ($this->check_url('wp-admin/edit-tags.php'))		
+		if ($this->check_url('wp-admin/edit-tags.php'))
 		{
 			global $taxonomy;
 			?>
@@ -2516,7 +2519,7 @@ class SimplyExclude
 				?>
 			</div><?php
 		}
-		else if ($this->check_url('wp-admin/edit.php'))		
+		else if ($this->check_url('wp-admin/edit.php'))
 		{
 			global $post_type;
 			?>
@@ -2543,26 +2546,26 @@ class SimplyExclude
 			<?php
 		}
 	}
-	
+
 	function se_ajax_update() {
 
 		//echo "_REQUEST<pre>"; print_r($_REQUEST); echo "</pre>";
 		//die();
 		if ( !current_user_can('manage_options') )
 			die();
-			
+
 		if ((isset($_REQUEST['se_action'])) && ($_REQUEST['se_action'] == "se_update_terms"))
 		{
 			if (!isset($_REQUEST['is_checked'])) die();
 			if (($_REQUEST['is_checked'] != 'yes') && ($_REQUEST['is_checked'] != 'no')) die();
 
 			$is_checked = $_REQUEST['is_checked'];
-			
+
 			if (isset($_REQUEST['se_cfg']))
 			{
 				$this->se_load_config();
 				$se_cfg = $_REQUEST['se_cfg'];
-				
+
 				$arg_parts = explode('[', $se_cfg);
 				foreach($arg_parts as $idx => $val)
 				{
@@ -2593,12 +2596,12 @@ class SimplyExclude
 					die();
 				}
 				else if ($arg_parts[1] == "plugins")
-				{					
+				{
 					if ($is_checked == "yes")
 						$this->se_cfg['options'][$arg_parts[1]][$arg_parts[2]]['actions'][$arg_parts[3]][$arg_parts[4]] = true;
 					else
 						$this->se_cfg['options'][$arg_parts[1]][$arg_parts[2]]['actions'][$arg_parts[3]][$arg_parts[4]] = false;
-						
+
 					$this->se_save_config();
 					echo "SUCCESS";
 					die();
@@ -2608,7 +2611,7 @@ class SimplyExclude
 					$post_type 	= $arg_parts[1];
 					$action		= $arg_parts[3];
 					$term_id	= $arg_parts[4];
-					
+
 					if ($is_checked == 'yes')
 					{
 						if (!isset($this->se_cfg['data']['post_types'][$post_type]['terms'][$action]))
@@ -2648,15 +2651,15 @@ class SimplyExclude
 			}
 		}
 		else if ((isset($_REQUEST['se_action'])) && ($_REQUEST['se_action'] == "se_update_actions"))
-		{			
+		{
 			if (!isset($_REQUEST['is_checked']))
 				die();
-				
+
 			//if (($_REQUEST['is_checked'] != 'i') && ($_REQUEST['is_checked'] != 'e'))
 			//	die();
-				
+
 			$is_checked = $_REQUEST['is_checked'];
-			
+
 			if (isset($_REQUEST['se_cfg']))
 			{
 				$this->se_load_config();
@@ -2685,7 +2688,7 @@ class SimplyExclude
 					{
 						$this->se_cfg['data']['se_types'][$se_type][$option][$action] = $is_checked;
 					}
-					
+
 					$this->se_save_config();
 					echo "SUCCESS";
 					die();
@@ -2746,10 +2749,10 @@ class SimplyExclude
 				<p><?php _e("So what is the difference between <strong>Include only</strong> and <strong>Exclude</strong>?", SIMPLY_EXCLUDE_I18N_DOMAIN); ?></p>
 				<p><strong><?php _e("Include only", SIMPLY_EXCLUDE_I18N_DOMAIN); ?></strong>: <?php _e("For example you have 3 Users but always want to show Posts for only 1  specific User in the Archives. New Users are automatically hidden.", SIMPLY_EXCLUDE_I18N_DOMAIN); ?></p>
 				<p><strong><?php _e("Exclude", SIMPLY_EXCLUDE_I18N_DOMAIN); ?></strong>: <?php _e("For example you have 3 Users but want to hide Posts from one User in the Archives. New Users will by visible.", SIMPLY_EXCLUDE_I18N_DOMAIN); ?></p>
-				
+
 				<?php
 				break;
-				
+
 			case 'taxonomy':
 				?>
 				<p><?php _e("Set the checkbox to exclude the Taxonomy items from the action", SIMPLY_EXCLUDE_I18N_DOMAIN); ?></p>
@@ -2758,7 +2761,7 @@ class SimplyExclude
 				<p><strong><?php _e("Exclude", SIMPLY_EXCLUDE_I18N_DOMAIN); ?></strong>: <?php _e("For example you have 100 categories but want to hide 3 from being seen. New tags will be visible.", SIMPLY_EXCLUDE_I18N_DOMAIN); ?></p>
 				<?php
 				break;
-				
+
 			case 'post_type':
 				?>
 				<p><?php _e("Set the checkbox to exclude the Post Type items from the action", SIMPLY_EXCLUDE_I18N_DOMAIN); ?></p>
@@ -2767,7 +2770,7 @@ class SimplyExclude
 				<p><strong><?php _e("Exclude", SIMPLY_EXCLUDE_I18N_DOMAIN); ?></strong>: <?php _e("For example you have 10 Pages and want to hide 3 specific Pages from Search. New Pages will be visible.", SIMPLY_EXCLUDE_I18N_DOMAIN); ?></p>
 				<?php
 				break;
-				
+
 			default:
 				break;
 		}
@@ -2779,14 +2782,14 @@ class SimplyExclude
 		?>
 		<div id="howto-se-manage-settings-metaboxes-general" class="wrap">
 			<?php screen_icon('options-general'); ?>
-			<h2><?php //_ex("Simply Exclude Manage Settings", "Options Page Title", SIMPLY_EXCLUDE_I18N_DOMAIN); 
+			<h2><?php //_ex("Simply Exclude Manage Settings", "Options Page Title", SIMPLY_EXCLUDE_I18N_DOMAIN);
 				foreach( $this->tabs as $tab => $name ){
 
 			        $class = ( $tab == $this->current_tab ) ? ' nav-tab-active' : '';
 			        echo "<a class='nav-tab$class' href='?page=se_manage_settings&tab=$tab'>$name</a>";
-			    } 
+			    }
 			?></h2>
-		
+
 			<div id="poststuff" class="metabox-holder has-right-sidebar simplyexclude-metabox-holder-right-sidebar">
 				<div id="side-info-column" class="inner-sidebar">
 					<?php do_meta_boxes($this->pagehooks['se_manage_settings'], 'side', ''); ?>
@@ -2798,10 +2801,10 @@ class SimplyExclude
 							switch ( $this->current_tab ) {
 
 								case 'post_types':
-									//add_meta_box('se_display_options_post_type_actions_panel', 'Post Types Actions', 
-									//	array(&$this, 'se_display_options_post_type_actions_panel'), 
+									//add_meta_box('se_display_options_post_type_actions_panel', 'Post Types Actions',
+									//	array(&$this, 'se_display_options_post_type_actions_panel'),
 									//	$this->pagehooks['se_manage_settings'], 'normal', 'core');
-									$this->se_display_options_post_type_actions_panel();									
+									$this->se_display_options_post_type_actions_panel();
 									break;
 
 								case 'users':
@@ -2812,17 +2815,17 @@ class SimplyExclude
 
 					    		case 'taxonomies':
 								default:
-									//add_meta_box('se_display_options_taxonomy_actions_panel', 'Taxonomies Actions', 
-									//	array(&$this, 'se_display_options_taxonomy_actions_panel'), 
+									//add_meta_box('se_display_options_taxonomy_actions_panel', 'Taxonomies Actions',
+									//	array(&$this, 'se_display_options_taxonomy_actions_panel'),
 									//	$this->pagehooks['se_manage_settings'], 'normal', 'core');
 									$this->se_display_options_taxonomy_actions_panel();
 									break;
 							}
 						?>
-						
+
 					</div>
 				</div>
-			</div>	
+			</div>
 		</div>
 		<script type="text/javascript">
 			//<![CDATA[
@@ -2833,13 +2836,13 @@ class SimplyExclude
 				postboxes.add_postbox_toggles('<?php echo $this->pagehooks['se_manage_settings']; ?>');
 			});
 			//]]>
-		</script>		
+		</script>
 		<?php
 	}
 
 	function se_display_options_taxonomy_actions_panel()
 	{
-		$this->display_instructions('taxonomy'); 
+		$this->display_instructions('taxonomy');
 		$se_taxonomies = $this->se_load_taxonomy_list();
 		if ($se_taxonomies)
 		{
@@ -2852,7 +2855,7 @@ class SimplyExclude
 						<?php
 						$this->se_show_taxonomy_active_panel($taxonomy->name);
 						$this->se_show_taxonomy_actions_panel($taxonomy->name);
-						$this->se_show_taxonomy_showhide_panel($taxonomy->name);				
+						$this->se_show_taxonomy_showhide_panel($taxonomy->name);
 						$this->se_show_taxonomy_query_override_panel($taxonomy->name);
 						?>
 					</div>
@@ -2884,9 +2887,9 @@ class SimplyExclude
 				</div>
 				<?php
 			}
-		}				
+		}
 	}
-	
+
 	function se_display_options_user_actions_panel()
 	{
 		$this->display_instructions('users');
@@ -2904,33 +2907,33 @@ class SimplyExclude
 		</div>
 		<?php
 	}
-	
+
 	function se_display_configuration_reload_actions_panel() {
-	
+
 		if ((isset($_POST['simple-exclude-configuration-reload'])) && ($_POST['simple-exclude-configuration-reload'] == "Yes")) {
-			
+
 			$local_cfg = $this->se_convert_configuration();
 			if ($local_cfg) {
 				$this->se_cfg = $local_cfg;
 				$this->se_save_config();
-				
+
 				?><p><strong><?php _e('Your Simply Excluded has successfully been reloaded.', SIMPLY_EXCLUDE_I18N_DOMAIN); ?></strong></p><?php
-			}			
+			}
 		}
-		?><p><?php _e('Version 2.0 and 2.0.1 of the plugins incorrectly converted your previous configuration of excluded items into a new format. You can use this 
+		?><p><?php _e('Version 2.0 and 2.0.1 of the plugins incorrectly converted your previous configuration of excluded items into a new format. You can use this
 			option to force a reload of your Simply Exclude configuration into the new format.', SIMPLY_EXCLUDE_I18N_DOMAIN); ?></p>
-		
+
 		<form name="" method="post" action"">
 			<select id="simple-exclude-configuration-reload" name="simple-exclude-configuration-reload">
 				<option value="">No</option>
 				<option value="Yes">Yes</option>
 			</select><br />
 			<input type="submit" value="<?php _e('Reload Configuration', SIMPLY_EXCLUDE_I18N_DOMAIN); ?>" />
-			
+
 		</form>
 		<?php
 	}
-	
+
 	function se_options_thirdparty_panel()
 	{
 		?>
@@ -2974,9 +2977,9 @@ class SimplyExclude
 								{
 									?>
 									<input type="checkbox" class="se-term-input"
-										name="se_cfg[plugins][<?php echo $option_key; ?>][<?php 
+										name="se_cfg[plugins][<?php echo $option_key; ?>][<?php
 											echo $option_actions_idx; ?>][update]"
-										<?php if ($option_actions_set['update'] === true) 
+										<?php if ($option_actions_set['update'] === true)
 											echo "checked='checked'"; ?> /> <?php echo $option_actions_set['desc']?><br />
 									<?php
 								}
@@ -2985,39 +2988,39 @@ class SimplyExclude
 						?>
 
 					</td>
-				</tr>					
+				</tr>
 				<?php
 			}
 		?>
 		</tbody>
-		</table>		
+		</table>
 
 		<?php
 	}
-	
+
 	function se_settings_about_sidebar()
 	{
-		?><p><a class="" target="_blank" href="http://www.codehooligans.com/projects/wordpress/simply-exclude/"><?php 
+		?><p><a class="" target="_blank" href="http://www.codehooligans.com/projects/wordpress/simply-exclude/"><?php
 			_e('Plugin Homepage', SIMPLY_EXCLUDE_I18N_DOMAIN); ?></a></p><?php
-		
+
 	}
 	function se_settings_donate_sidebar()
 	{
 		?>
 		<p><?php _e('Show your support of this plugin by making a small donation to support future development. No donation amount too small.',
 		 	SIMPLY_EXCLUDE_I18N_DOMAIN); ?></p>
-		<p><a class="" target="_blank" href="http://www.codehooligans.com/donations/"><?php 
+		<p><a class="" target="_blank" href="http://www.codehooligans.com/donations/"><?php
 			_e('Make a donation today', SIMPLY_EXCLUDE_I18N_DOMAIN); ?></a></p>
 		<?php
 	}
-	
+
 	function se_manage_help()
 	{
 		?>
 		<div id="se-manage-help-metaboxes-general" class="wrap">
 		<?php screen_icon('options-general'); ?>
 		<h2><?php _ex("Simply Exclude Help", "Options Page Title", SIMPLY_EXCLUDE_I18N_DOMAIN); ?></h2>
-		
+
 			<div id="poststuff" class="metabox-holder has-right-sidebar simplyexclude-metabox-holder-right-sidebar">
 				<div id="side-info-column" class="inner-sidebar">
 					<?php do_meta_boxes($this->pagehooks['se_manage_help'], 'side', ''); ?>
@@ -3028,9 +3031,9 @@ class SimplyExclude
 						<?php $this->se_settings_help_faq_topics(); ?>
 					</div>
 				</div>
-			</div>	
+			</div>
 		</div>
-		
+
 		<script>
 			jQuery(document).ready(function() {
 				jQuery( "#se-accordion" ).accordion();
@@ -3068,15 +3071,15 @@ class SimplyExclude
 				<p><strong>Show</strong>: If you set the state to <strong>Show</strong> the plugin code will add a new column to the Taxonomy/Post Type listing tables. The plug will also add a new set of fields to the Taxonomy/Post Type editor form.</p>
 				<p><strong>Disabled</strong>: If you set the state to <strong>Disabled</strong> the plugin will not add a new column to the Taxonomy/Post Type listing tables. Nor will it add a new set of fields to the Taxonomy/Post Type editor form.</p>
 			</div>
-			
+
 			<h3><a href="#">I'm still confuses on the concepts of 'Include only' vs. 'Exclude' vs. 'Include all' action states</a></h3>
 			<div>
 				<p><strong>Include only</strong>: This setting tells the plugin to include only these selected items within the filtering logic. Let us take a example. Assume you have 100 Category terms and you want to only show 3 of these Category terms on the Front/Home post listing. You could setup the logic to exclude the other 97 Category terms. The problem with this is when you are more categories which you also don't want show on the Front/Home listing you will need to remember to exclude these. Instead the <strong>Include only</strong> lets you set only the 3 Categories to be included. Now as more Categories are added they will automatically be excluded from the Front/Home listing.</p>
-								
+
 				<p><strong>Exclude</strong>: This action state is the simpler to understand. Quite simply you set this to Exclude Taxonomy or Post Type items from the available actions, Archive, Feeds, Searches, etc.</p>
 				<p><strong>Include all</strong>: This is a special action state only available to Post Types compatible with <strong>Post</strong>. When using this special action state you can include the Post Type into the output of the other Post Types. For example in the default WordPress setup a site will display the latest Posts on the front page. Now assume you have a Custom Post Type 'Books' you also want to show on the front page. To accomplish this you would set both <strong>Posts</strong> and <strong>Books</strong> Post Types to the <strong>Include All</strong> action state.</p>
 			</div>
-			
+
 			<h3><a href="#">Can I use the Simply Exclude plugin to include other Post Types on my front page?</a></h3>
 			<div>
 				<p>Short answer, YES! Longer answer. This can be done but you need to be careful with the setup. This <em>could</em> effect how other post_types are displayed.</p>
@@ -3086,20 +3089,20 @@ class SimplyExclude
 					<li>The first assumption is you have your WordPress system setup to show your latest posts on your Home page and not a static Page.</li>
 					<li>Next, it is assumed you have setup a Custom Post Type. And this Post Type is compatible with the legacy <strong>Post</strong> type and not <strong>Page</strong> type.</li>
 				</ol>
-				
+
 				<p>Here is the setup</p>
 				<ol>
 					<li>Go to the Simply Exclude <a href="admin.php?page=se_manage_settings">Settings panel</a>. Location the Post Type you want to manage</li>
 					<li>On the sub-panel ensure the Post Type is <strong>Active</strong>. Next, find the row for <strong>Front/Home</strong>. Ensure the selection is set to <strong>Include All</strong>. Finally, ensure the <strong>Show/Hide</strong> option is set to <strong>Show</strong>.</li>
-					<li>Now navigate to the Post Type listing. This is important. You must ensure no items are set to <strong>Include Only</strong> or <strong>Exclude</strong> for this Post Type.</li> 
+					<li>Now navigate to the Post Type listing. This is important. You must ensure no items are set to <strong>Include Only</strong> or <strong>Exclude</strong> for this Post Type.</li>
 				</ol>
 
 				<p><strong>Notes:</strong></p>
 				<p>You can mix Post Types to include on the Home/Front page. For example you have a custom Post Type Books and you want to show Books and Posts on the Home/Front page. You should set both Post Types to <strong>Include All</strong>. You would also set one or both Post Types to <strong>Include only</strong>. The result is only those checked items will be includes. Similar results setting the Post Types to <strong>Exclude</strong> will exclude only those Post Type item.</li>
 					But the process is trial and errors. You need to make sure you review this in your own setup.</p>
 
-				<p>Also beware of setting one Post Type to <strong>Include all</strong> or <strong>Include only</strong> then setting a second Post Type as <strong>Exclude</strong>. The <strong>Exclude</strong> Post Type items will be processed while the <strong>Include all/only</strong> items will be ignored</p>	
-				
+				<p>Also beware of setting one Post Type to <strong>Include all</strong> or <strong>Include only</strong> then setting a second Post Type as <strong>Exclude</strong>. The <strong>Exclude</strong> Post Type items will be processed while the <strong>Include all/only</strong> items will be ignored</p>
+
 				<p>You can also use the <strong>Include all</strong> on the Feeds actions for Post Types</p>
 			</div>
 
@@ -3107,12 +3110,12 @@ class SimplyExclude
 			<div>
 				<p>My suggestion is to start on the Simply Exclude <a href="admin.php?page=se_manage_settings">Settings panel</a>. For each Taxonomy and Post Type set the Active state to <strong>Disabled</strong>. Then one at a time enable a Taxonomy and check your site. Depending on the number of Taxonomies and Custom Post Types you may be introducing a conflict my including one set of items then excluding them at the same time.</p>
 			</div>
-			
+
 			<h3><a href="#">I've excluded all my categories and all tags. Why am I seeing a 404 page?</a></h3>
 			<div>
 				<p>Well you need to be careful when excluding both categories and tags. Since a post can be associated with both Categories and Tags there is potential that you have excluded all your posts because they are either members of excluded categories and/or members or excluded tags.</p>
 			</div>
-			
+
 			<h3><a href="#">I've excluded Pages but attachments (images) for those pages are showing up. Why?</a></h3>
 			<div>
 				<p>Only the parent Page itself is excluded from searches. By default WordPress does not yet include Pages in search. Make sure you have other search plugins correctly configured to not search attachments.</p>
@@ -3135,13 +3138,13 @@ class SimplyExclude
 				<p>One important piece of information is to understand how the WP_Query system works within WordPress. If you have one Post Types where you are setting the <strong>Include only</strong>. This will execute before any excludes. This is just the way WordPress works and not something the plugin can control.</p>
 				<p>Let's consider an example. Assume you have the default Post Type <strong>Posts</strong> setup to <strong>Include only</strong> for the Front/Home. Now also assume you have a custom Post Type name <strong>Books</strong> and this action state is set to 'Include All'. When you view the Front/Home page you only see the Posts but not the Books? Why? Because WordPress see the <strong>Include only</strong> as a higher request. If both are included in your setup the <strong>Include only</strong> will be processed while the additional <strong>Exclude</strong> or <strong>Include all</strong> will be ignored.</p>
 				<p>To summarize. You can combine <strong>Exclude</strong> and <strong>Include all</strong> options with in the same Taxonomy or Post Type. But if you combine <strong>Include only</strong> with other action states like <strong>Exclude</strong> or <strong>Include all</strong> only the <strong>Include only</strong> information will be used.</p>
-					
+
 			</div>
 		</div>
 		<?php
 	}
-	
-	
+
+
 	/****************************************************************************************************************************/
 	/*																															*/
 	/*												UTILITY FUNCTIONS															*/
@@ -3167,14 +3170,14 @@ class SimplyExclude
 	{
 		//echo "ids_array<pre>"; print_r($ids_array); echo "</pre>";
 		//echo "action=[". $action ."]<br />";
-		
+
 		$id_list = "";
-		
+
 		if ($action == "e")
 			$action_value = "-";
 		else
 			$action_value = "";
-			
+
 		foreach($ids_array as $id_key => $id_val)
 		{
 			if (strlen($id_list))


### PR DESCRIPTION
This plugin is awesome, but I found that with the current default confing, users cannot exclude custom post types like projects from homepages or archives, only the search option appears in the backend in the exclude box.

here is an before and after this commit
**Before**
![before](https://cloud.githubusercontent.com/assets/1893980/11302536/c3fb521c-8fa6-11e5-98ef-5a7b6d932b94.png)

**After**
![after](https://cloud.githubusercontent.com/assets/1893980/11302554/d3c71442-8fa6-11e5-9af4-58ce21496ebb.png)
